### PR TITLE
[core] Align lines when printing module scope list

### DIFF
--- a/core/src/main/cpp/main/src/config_manager.cpp
+++ b/core/src/main/cpp/main/src/config_manager.cpp
@@ -194,7 +194,7 @@ namespace lspd {
                     scope.emplace(std::move(app_pkg_name));
             }
             if (IsInstaller(module_pkg_name)) scope.erase("android");
-            LOGI("scope of %s is:\n%s", module_pkg_name.c_str(), ([&scope = scope]() {
+            LOGI("scope of %s is:\n  %s", module_pkg_name.c_str(), ([&scope = scope]() {
                 std::ostringstream join;
                 std::copy(scope.begin(), scope.end(),
                           std::ostream_iterator<std::string>(join, "\n  "));


### PR DESCRIPTION
```
 * Without this commit, the lines are printed like this:

   02-03 21:00:20.488   987   987 I LSPosed : scope of com.mhook.dialog.beta is:
   02-03 21:00:20.488   987   987 I LSPosed : com.bug.zqq
   02-03 21:00:20.488   987   987 I LSPosed :   com.tencent.mobileqq
   02-03 21:00:20.488   987   987 I LSPosed :   com.heytap.themestore
   02-03 21:00:20.488   987   987 I LSPosed :   com.mhook.dialog.beta
```