### PR TITLE
[core] Remove useless code

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -1,4 +1,6 @@
--keep class org.lsposed.manager.Constants { *; }
+-keep class org.lsposed.manager.Constants {
+    public static void showErrorToast(int);
+}
 -keepclasseswithmembers class org.lsposed.manager.receivers.LSPosedManagerServiceClient {
     private static android.os.IBinder binder;
 }

--- a/app/src/main/java/org/lsposed/manager/Constants.java
+++ b/app/src/main/java/org/lsposed/manager/Constants.java
@@ -22,21 +22,9 @@ package org.lsposed.manager;
 
 import android.widget.Toast;
 
-@SuppressWarnings({"FieldCanBeLocal", "FieldMayBeFinal"})
 public class Constants {
-    private static int xposedApiVersion = -1;
-    private static String xposedVersion = null;
 
     public static void showErrorToast(int type) {
         Toast.makeText(App.getInstance(), R.string.app_destroyed, Toast.LENGTH_LONG).show();
-    }
-
-    // for showing the version mismatch dialog
-    public static String getXposedVersion() {
-        return xposedVersion;
-    }
-
-    public static int getXposedApiVersion() {
-        return xposedApiVersion;
     }
 }

--- a/app/src/main/java/org/lsposed/manager/ui/activity/base/BaseActivity.java
+++ b/app/src/main/java/org/lsposed/manager/ui/activity/base/BaseActivity.java
@@ -34,7 +34,6 @@ import androidx.appcompat.app.AlertDialog;
 import org.lsposed.manager.App;
 import org.lsposed.manager.BuildConfig;
 import org.lsposed.manager.ConfigManager;
-import org.lsposed.manager.Constants;
 import org.lsposed.manager.R;
 import org.lsposed.manager.util.NavUtil;
 import org.lsposed.manager.util.theme.ThemeUtil;
@@ -55,10 +54,6 @@ public class BaseActivity extends MaterialActivity {
 
         // make sure the versions are consistent
         String coreVersionStr = ConfigManager.getXposedVersionName();
-        // for showing the version mismatch dialog
-        if (coreVersionStr == null) {
-            coreVersionStr = Constants.getXposedVersion();
-        }
         if (coreVersionStr != null) {
             if (!BuildConfig.VERSION_NAME.equals(coreVersionStr)) {
                 new AlertDialog.Builder(this)

--- a/core/src/main/java/org/lsposed/lspd/hooker/XposedInstallerHooker.java
+++ b/core/src/main/java/org/lsposed/lspd/hooker/XposedInstallerHooker.java
@@ -39,19 +39,5 @@ public class XposedInstallerHooker {
         } catch (Throwable t) {
             Utils.logW("Could not hook LSPosed Manager", t);
         }
-
-        // for showing the version mismatch dialog
-        try {
-            Class<?> ConstantsClass = XposedHelpers.findClass("org.lsposed.manager.Constants", classLoader);
-            try {
-                XposedHelpers.setStaticObjectField(ConstantsClass, "xposedVersion", BuildConfig.VERSION_NAME);
-                return;
-            } catch (Throwable ignore) {
-
-            }
-            XposedHelpers.findAndHookMethod(ConstantsClass, "getXposedVersion", XC_MethodReplacement.returnConstant(BuildConfig.VERSION_NAME));
-        } catch (Throwable ignore) {
-
-        }
     }
 }

--- a/core/src/main/java/org/lsposed/lspd/service/PackageService.java
+++ b/core/src/main/java/org/lsposed/lspd/service/PackageService.java
@@ -252,8 +252,7 @@ public class PackageService {
                 boolean signatureMatch = InstallerVerifier.verifyInstallerSignature(pkgInfo.applicationInfo);
                 if (versionMatch && signatureMatch && pkgInfo.versionCode >= BuildConfig.VERSION_CODE)
                     return false;
-                if (!BuildConfig.DEFAULT_MANAGER_PACKAGE_NAME.equals(packageName) || !signatureMatch
-                        || !versionMatch && pkgInfo.versionCode > BuildConfig.VERSION_CODE)
+                if (!signatureMatch || !versionMatch && pkgInfo.versionCode > BuildConfig.VERSION_CODE)
                     uninstallPackage(new VersionedPackage(pkgInfo.packageName, pkgInfo.versionCode));
             }
 


### PR DESCRIPTION
Since we change the package name, we don't have to hook old manager
which use contants.

Since we have released new stable version, we should prepare for
randomize package name and therefore don't need to fix package name
mismatch.