### PR TITLE
[core] Remove @FastNative annotation of onPostFixupStaticTrampolines()

### DIFF
--- a/core/src/main/java/org/lsposed/lspd/nativebridge/ClassLinker.java
+++ b/core/src/main/java/org/lsposed/lspd/nativebridge/ClassLinker.java
@@ -30,7 +30,6 @@ public class ClassLinker {
     @FastNative
     public static native void setEntryPointsToInterpreter(Executable method);
 
-    @FastNative
     public static void onPostFixupStaticTrampolines(Class<?> clazz) {
         // native flags will be re-set in hooking logic
         PendingHooks.hookPendingMethod(clazz);


### PR DESCRIPTION
 * This is not even a native method.