### PR TITLE
[core] Refine native api

### DIFF
--- a/core/src/main/cpp/main/src/native_api.cpp
+++ b/core/src/main/cpp/main/src/native_api.cpp
@@ -25,7 +25,7 @@
 #include "native_api.h"
 #include "symbol_cache.h"
 #include <dobby.h>
-#include <vector>
+#include <list>
 #include <base/object.h>
 
 /*
@@ -44,8 +44,8 @@
  */
 
 namespace lspd {
-    std::vector<NativeOnModuleLoaded> moduleLoadedCallbacks;
-    std::vector<std::string> moduleNativeLibs;
+    std::list<NativeOnModuleLoaded> moduleLoadedCallbacks;
+    std::list<std::string> moduleNativeLibs;
     std::unique_ptr<void, std::function<void(void *)>> protected_page(
             mmap(nullptr, _page_size, PROT_READ | PROT_WRITE, MAP_ANONYMOUS | MAP_SHARED, -1, 0),
             [](void *ptr) { munmap(ptr, _page_size); });

--- a/core/src/main/java/de/robv/android/xposed/XposedInit.java
+++ b/core/src/main/java/de/robv/android/xposed/XposedInit.java
@@ -387,8 +387,8 @@ public final class XposedInit {
         } catch (ClassNotFoundException ignored) {
         }
 
-        boolean res = initModule(mcl, apk);
-        res = res && initNativeModule(mcl, apk);
+        boolean res = initNativeModule(mcl, apk);
+        res = res && initModule(mcl, apk);
         return res;
     }
 

--- a/core/src/main/java/de/robv/android/xposed/XposedInit.java
+++ b/core/src/main/java/de/robv/android/xposed/XposedInit.java
@@ -387,9 +387,7 @@ public final class XposedInit {
         } catch (ClassNotFoundException ignored) {
         }
 
-        boolean res = initNativeModule(mcl, apk);
-        res = res && initModule(mcl, apk);
-        return res;
+        return initNativeModule(mcl, apk) && initModule(mcl, apk);
     }
 
     public final static HashSet<String> loadedPackagesInProcess = new HashSet<>(1);


### PR DESCRIPTION
- No need to use `vector`. `list` is enough
- Someone calling `System.LoadLibrary` in the static field in java will miss the native hook, so reverse the loading order.