### PR TITLE
[core] Remove trailing slash for /data/adb/lspd

### DIFF
--- a/core/magisk_module/customize.sh
+++ b/core/magisk_module/customize.sh
@@ -69,7 +69,7 @@ extract "$ZIPFILE" 'sepolicy.rule'      "$MODPATH"
 extract "$ZIPFILE" 'post-fs-data.sh'    "$MODPATH"
 extract "$ZIPFILE" 'uninstall.sh'       "$MODPATH"
 extract "$ZIPFILE" 'framework/lspd.dex' "$MODPATH"
-extract "$ZIPFILE" 'manager.apk'        '/data/adb/lspd/'
+extract "$ZIPFILE" 'manager.apk'        '/data/adb/lspd'
 
 mkdir "$MODPATH/riru"
 mkdir "$MODPATH/riru/lib"


### PR DESCRIPTION
 * Which causes unzip fail because it becomes /data/adb/lspd//...