### PR TITLE
Add versionCode to the 'version' displayed in the Magisk module

### DIFF
--- a/core/magisk_module/module.prop
+++ b/core/magisk_module/module.prop
@@ -1,6 +1,6 @@
 id=${moduleId}
 name=Riru - LSPosed
-version=${versionName}
+version=${versionName}(${versionCode})
 versionCode=${versionCode}
 author=${authorList}
 description=Another enhanced implementation of Xposed Framework. Supports Android 8.1 ~ 12 DP3. Requires Riru ${minRiruVersionName} or above installed.

--- a/core/magisk_module/module.prop
+++ b/core/magisk_module/module.prop
@@ -1,6 +1,6 @@
 id=${moduleId}
 name=Riru - LSPosed
-version=${versionName}(${versionCode})
+version=${versionName} (${versionCode})
 versionCode=${versionCode}
 author=${authorList}
 description=Another enhanced implementation of Xposed Framework. Supports Android 8.1 ~ 12 DP3. Requires Riru ${minRiruVersionName} or above installed.


### PR DESCRIPTION
Used to get the version code more clearly from the Magisk module list.