### PR TITLE
[core] Startup daemon in service.sh if post-fs-data.sh stucks

### DIFF
--- a/core/magisk_module/customize.sh
+++ b/core/magisk_module/customize.sh
@@ -66,6 +66,7 @@ extract "$ZIPFILE" 'module.prop'        "$MODPATH"
 extract "$ZIPFILE" 'system.prop'        "$MODPATH"
 extract "$ZIPFILE" 'sepolicy.rule'      "$MODPATH"
 extract "$ZIPFILE" 'post-fs-data.sh'    "$MODPATH"
+extract "$ZIPFILE" 'service.sh'         "$MODPATH"
 extract "$ZIPFILE" 'uninstall.sh'       "$MODPATH"
 extract "$ZIPFILE" 'framework/lspd.dex' "$MODPATH"
 extract "$ZIPFILE" 'manager.apk'        '/data/adb/lspd'

--- a/core/magisk_module/post-fs-data.sh
+++ b/core/magisk_module/post-fs-data.sh
@@ -138,10 +138,9 @@ fi
 start_app_process() {
   while true; do
     if [ -S "/dev/socket/zygote" ]; then
-      nohup /system/bin/app_process -Djava.class.path=$(magisk --path)/.magisk/modules/riru_lsposed/framework/lspd.dex /system/bin --nice-name=lspd org.lsposed.lspd.core.Main >/dev/null 2>&1 &
+      nohup /system/bin/app_process -Djava.class.path=$(magisk --path)/.magisk/modules/riru_lsposed/framework/lspd.dex /system/bin --nice-name=lspd org.lsposed.lspd.core.Main >/dev/null 2>&1 & echo $! > /data/adb/lspd/daemon.pid
       return
     fi
   done
 }
-
-start_app_process &
+start_app_process & echo $! > /data/adb/lspd/daemon.pid

--- a/core/magisk_module/service.sh
+++ b/core/magisk_module/service.sh
@@ -1,0 +1,31 @@
+#!/system/bin/sh
+
+#
+# This file is part of LSPosed.
+#
+# LSPosed is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# LSPosed is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with LSPosed.  If not, see <https://www.gnu.org/licenses/>.
+#
+# Copyright (C) 2021 LSPosed Contributors
+#
+
+CMDLINE="$(cat /proc/$(cat /data/adb/lspd/daemon.pid)/cmdline)"
+
+# if still waiting for zygote, cmdline should be like:
+# $(magisk --path)/.magisk/busybox/busyboxsh/data/adb/modules/riru_lsposed/post-fs-data.sh
+# if service started, cmdline should be lspd
+# for other cases, post-fs-data.sh may not be executed properly
+if [ "${CMDLINE##*riru_lsposed/}" != "post-fs-data.sh" ] && [ "$CMDLINE" != "lspd" ]; then
+  log -pw -t "LSPosedService" "LSPosed daemon is not started properly. Try for a late start..."
+  nohup /system/bin/app_process -Djava.class.path=$(magisk --path)/.magisk/modules/riru_lsposed/framework/lspd.dex /system/bin --nice-name=lspd org.lsposed.lspd.core.Main >/dev/null 2>&1 & echo $! > /data/adb/lspd/daemon.pid
+fi


### PR DESCRIPTION
Some modules may stick `post-fs-data.sh` of Magisk (for example running `resetprop`), leaving daemon unstarted.
In such case, we should try to startup daemon in `service.sh` though it's a bit too late.