### PR TITLE
[core] Correct process name for android in module log

### DIFF
--- a/core/src/main/java/org/lsposed/lspd/nativebridge/ModuleLogger.java
+++ b/core/src/main/java/org/lsposed/lspd/nativebridge/ModuleLogger.java
@@ -58,7 +58,7 @@ public class ModuleLogger {
         sb.append(' ');
         sb.append(isThrowable ? "E" : "I");
         sb.append('/');
-        sb.append(processName == null ? "?" : processName);
+        sb.append(processName == null ? "android" : processName);
         sb.append('(');
         sb.append(Process.myPid());
         sb.append('-');


### PR DESCRIPTION
 * It can only be NULL when in system_server.