### PR TITLE
[app] Call getEnabledModules() in reloadSingleModule()

### DIFF
--- a/app/src/main/java/org/lsposed/manager/util/ModuleUtil.java
+++ b/app/src/main/java/org/lsposed/manager/util/ModuleUtil.java
@@ -103,6 +103,10 @@ public final class ModuleUtil {
 
     public InstalledModule reloadSingleModule(String packageName, int userId) {
         PackageInfo pkg;
+
+        // Call getEnabledModules() here to let backend handle enabled status
+        enabledModules = new HashSet<>(Arrays.asList(ConfigManager.getEnabledModules()));
+
         try {
             pkg = ConfigManager.getPackageInfo(packageName, PackageManager.GET_META_DATA, userId);
             if (pkg == null) {


### PR DESCRIPTION
 * To get a reliable enabled status, we have to rely on
   backend every time a module is uninstalled from
   the manager.