### PR TITLE
[core] Load module in memory

### DIFF
--- a/core/src/main/java/de/robv/android/xposed/XposedInit.java
+++ b/core/src/main/java/de/robv/android/xposed/XposedInit.java
@@ -46,6 +46,7 @@ import android.util.Log;
 
 import org.lsposed.lspd.nativebridge.NativeAPI;
 import org.lsposed.lspd.nativebridge.ResourcesHook;
+import org.lsposed.lspd.util.InMemoryDelegateLastClassLoader;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -59,7 +60,6 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import dalvik.system.DelegateLastClassLoader;
 import de.robv.android.xposed.callbacks.XC_InitPackageResources;
 import de.robv.android.xposed.callbacks.XC_InitZygote;
 import de.robv.android.xposed.callbacks.XC_LoadPackage;
@@ -372,9 +372,8 @@ public final class XposedInit {
         for (String i : Build.SUPPORTED_ABIS) {
             nativePath.append(apk).append("!/lib/").append(i).append(File.pathSeparator);
         }
-        // Log.d(TAG, "Allowed native path" + nativePath.toString());
         ClassLoader initLoader = XposedInit.class.getClassLoader();
-        ClassLoader mcl = new DelegateLastClassLoader(apk, nativePath.toString(), initLoader);
+        ClassLoader mcl = InMemoryDelegateLastClassLoader.loadApk(new File(apk), nativePath.toString(), initLoader);
 
         try {
             if (mcl.loadClass(XposedBridge.class.getName()).getClassLoader() != initLoader) {

--- a/core/src/main/java/de/robv/android/xposed/XposedInit.java
+++ b/core/src/main/java/de/robv/android/xposed/XposedInit.java
@@ -26,7 +26,6 @@ import static de.robv.android.xposed.XposedBridge.sInitPackageResourcesCallbacks
 import static de.robv.android.xposed.XposedBridge.sInitZygoteCallbacks;
 import static de.robv.android.xposed.XposedBridge.sLoadedPackageCallbacks;
 import static de.robv.android.xposed.XposedHelpers.callMethod;
-import static de.robv.android.xposed.XposedHelpers.closeSilently;
 import static de.robv.android.xposed.XposedHelpers.findAndHookMethod;
 import static de.robv.android.xposed.XposedHelpers.getObjectField;
 import static de.robv.android.xposed.XposedHelpers.getParameterIndexByType;
@@ -51,7 +50,6 @@ import org.lsposed.lspd.util.InMemoryDelegateLastClassLoader;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.lang.ref.WeakReference;
 import java.lang.reflect.Method;
@@ -59,7 +57,9 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.zip.ZipFile;
 
+import dalvik.system.DelegateLastClassLoader;
 import de.robv.android.xposed.callbacks.XC_InitPackageResources;
 import de.robv.android.xposed.callbacks.XC_InitZygote;
 import de.robv.android.xposed.callbacks.XC_LoadPackage;
@@ -276,82 +276,101 @@ public final class XposedInit {
      * Load all so from an APK by reading <code>assets/native_init</code>.
      * It will only store the so names but not doing anything.
      */
-    private static boolean initNativeModule(ClassLoader mcl, String name) {
-        InputStream is = mcl.getResourceAsStream("assets/native_init");
-        if (is == null) return true;
-        BufferedReader moduleLibraryReader = new BufferedReader(new InputStreamReader(is));
-        String moduleLibraryName;
-        try {
+    private static boolean initNativeModule(String apk) {
+        try (var apkFile = new ZipFile(apk)) {
+            var init = apkFile.getEntry("assets/native_init");
+            if (init == null) return true;
+            var is = apkFile.getInputStream(init);
+            var moduleLibraryReader = new BufferedReader(new InputStreamReader(is));
+            String moduleLibraryName;
             while ((moduleLibraryName = moduleLibraryReader.readLine()) != null) {
                 if (!moduleLibraryName.startsWith("#")) {
                     NativeAPI.recordNativeEntrypoint(moduleLibraryName);
                 }
             }
         } catch (IOException e) {
-            Log.e(TAG, "  Failed to load native library list from " + name, e);
+            Log.e(TAG, "  Failed to load native library list from " + apk, e);
             return false;
-        } finally {
-            closeSilently(is);
         }
         return true;
-
     }
 
-    private static boolean initModule(ClassLoader mcl, String name, String apk) {
-        InputStream is = mcl.getResourceAsStream("assets/xposed_init");
-        if (is == null) {
-            return true;
-        }
-        BufferedReader moduleClassesReader = new BufferedReader(new InputStreamReader(is));
-        try {
-            String moduleClassName;
-            while ((moduleClassName = moduleClassesReader.readLine()) != null) {
-                moduleClassName = moduleClassName.trim();
-                if (moduleClassName.isEmpty() || moduleClassName.startsWith("#"))
+    private static boolean loadModule(ClassLoader mcl, BufferedReader reader, String apk) throws IOException {
+        String moduleClassName;
+        while ((moduleClassName = reader.readLine()) != null) {
+            moduleClassName = moduleClassName.trim();
+            if (moduleClassName.isEmpty() || moduleClassName.startsWith("#"))
+                continue;
+
+            try {
+                Log.i(TAG, "  Loading class " + moduleClassName);
+                Class<?> moduleClass = mcl.loadClass(moduleClassName);
+
+                if (!IXposedMod.class.isAssignableFrom(moduleClass)) {
+                    Log.e(TAG, "    This class doesn't implement any sub-interface of IXposedMod, skipping it");
                     continue;
+                } else if (disableResources && IXposedHookInitPackageResources.class.isAssignableFrom(moduleClass)) {
+                    Log.e(TAG, "    This class requires resource-related hooks (which are disabled), skipping it.");
+                    continue;
+                }
 
-                try {
-                    Log.i(TAG, "  Loading class " + moduleClassName);
-                    Class<?> moduleClass = mcl.loadClass(moduleClassName);
+                final Object moduleInstance = moduleClass.newInstance();
+                if (moduleInstance instanceof IXposedHookZygoteInit) {
+                    IXposedHookZygoteInit.StartupParam param = new IXposedHookZygoteInit.StartupParam();
+                    param.modulePath = apk;
+                    param.startsSystemServer = startsSystemServer;
 
-                    if (!IXposedMod.class.isAssignableFrom(moduleClass)) {
-                        Log.e(TAG, "    This class doesn't implement any sub-interface of IXposedMod, skipping it");
-                        continue;
-                    } else if (disableResources && IXposedHookInitPackageResources.class.isAssignableFrom(moduleClass)) {
-                        Log.e(TAG, "    This class requires resource-related hooks (which are disabled), skipping it.");
-                        continue;
-                    }
+                    XposedBridge.hookInitZygote(new IXposedHookZygoteInit.Wrapper(
+                            (IXposedHookZygoteInit) moduleInstance, param));
+                    ((IXposedHookZygoteInit) moduleInstance).initZygote(param);
+                }
 
-                    final Object moduleInstance = moduleClass.newInstance();
-                    if (moduleInstance instanceof IXposedHookZygoteInit) {
-                        IXposedHookZygoteInit.StartupParam param = new IXposedHookZygoteInit.StartupParam();
-                        param.modulePath = apk;
-                        param.startsSystemServer = startsSystemServer;
+                if (moduleInstance instanceof IXposedHookLoadPackage)
+                    XposedBridge.hookLoadPackage(new IXposedHookLoadPackage.Wrapper(
+                            (IXposedHookLoadPackage) moduleInstance, apk));
 
-                        XposedBridge.hookInitZygote(new IXposedHookZygoteInit.Wrapper(
-                                (IXposedHookZygoteInit) moduleInstance, param));
-                        ((IXposedHookZygoteInit) moduleInstance).initZygote(param);
-                    }
+                if (moduleInstance instanceof IXposedHookInitPackageResources)
+                    XposedBridge.hookInitPackageResources(new IXposedHookInitPackageResources.Wrapper(
+                            (IXposedHookInitPackageResources) moduleInstance, apk));
+            } catch (Throwable t) {
+                Log.e(TAG, "    Failed to load class " + moduleClassName, t);
+                return false;
+            }
+        }
+        return true;
+    }
 
-                    if (moduleInstance instanceof IXposedHookLoadPackage)
-                        XposedBridge.hookLoadPackage(new IXposedHookLoadPackage.Wrapper(
-                                (IXposedHookLoadPackage) moduleInstance, apk));
-
-                    if (moduleInstance instanceof IXposedHookInitPackageResources)
-                        XposedBridge.hookInitPackageResources(new IXposedHookInitPackageResources.Wrapper(
-                                (IXposedHookInitPackageResources) moduleInstance, apk));
-                } catch (Throwable t) {
-                    Log.e(TAG, "    Failed to load class " + moduleClassName, t);
+    private static boolean initModule(String name, String apk, String librarySearchPath, ClassLoader parent) {
+        try (var apkFile = new ZipFile(apk)) {
+            var init = apkFile.getEntry("assets/inmemory_xposed_init");
+            ClassLoader mcl;
+            if (init != null) {
+                mcl = InMemoryDelegateLastClassLoader.loadApk(new File(apk), librarySearchPath, parent);
+            } else {
+                init = apkFile.getEntry("assets/xposed_init");
+                if (init == null) return true;
+                mcl = new DelegateLastClassLoader(apk, librarySearchPath, parent);
+            }
+            try {
+                if (mcl.loadClass(XposedBridge.class.getName()).getClassLoader() != parent) {
+                    Log.e(TAG, "  Cannot load module: " + name);
+                    Log.e(TAG, "  The Xposed API classes are compiled into the module's APK.");
+                    Log.e(TAG, "  This may cause strange issues and must be fixed by the module developer.");
+                    Log.e(TAG, "  For details, see: http://api.xposed.info/using.html");
                     return false;
                 }
+            } catch (ClassNotFoundException e) {
+                Log.e(TAG, "  Failed to load module " + name + " from " + apk, e);
+                return false;
             }
+            var is = apkFile.getInputStream(init);
+            return loadModule(mcl, new BufferedReader(new InputStreamReader(is)), apk);
         } catch (IOException e) {
             Log.e(TAG, "  Failed to load module " + name + " from " + apk, e);
             return false;
         } finally {
-            closeSilently(is);
+            System.gc();
         }
-        return true;
     }
 
     /**
@@ -373,20 +392,7 @@ public final class XposedInit {
             nativePath.append(apk).append("!/lib/").append(i).append(File.pathSeparator);
         }
         ClassLoader initLoader = XposedInit.class.getClassLoader();
-        ClassLoader mcl = InMemoryDelegateLastClassLoader.loadApk(new File(apk), nativePath.toString(), initLoader);
-
-        try {
-            if (mcl.loadClass(XposedBridge.class.getName()).getClassLoader() != initLoader) {
-                Log.e(TAG, "  Cannot load module: " + name);
-                Log.e(TAG, "  The Xposed API classes are compiled into the module's APK.");
-                Log.e(TAG, "  This may cause strange issues and must be fixed by the module developer.");
-                Log.e(TAG, "  For details, see: http://api.xposed.info/using.html");
-                return false;
-            }
-        } catch (ClassNotFoundException ignored) {
-        }
-
-        return initNativeModule(mcl, apk) && initModule(mcl, name, apk);
+        return initNativeModule(apk) && initModule(name, apk, nativePath.toString(), initLoader);
     }
 
     public final static HashSet<String> loadedPackagesInProcess = new HashSet<>(1);

--- a/core/src/main/java/de/robv/android/xposed/XposedInit.java
+++ b/core/src/main/java/de/robv/android/xposed/XposedInit.java
@@ -345,6 +345,7 @@ public final class XposedInit {
             var init = apkFile.getEntry("assets/inmemory_xposed_init");
             ClassLoader mcl;
             if (init != null) {
+                Log.i(TAG, "Loading in-memory module " + name+ ", skip parsing xposed_init");
                 mcl = InMemoryDelegateLastClassLoader.loadApk(new File(apk), librarySearchPath, parent);
             } else {
                 init = apkFile.getEntry("assets/xposed_init");

--- a/core/src/main/java/org/lsposed/lspd/util/InMemoryDelegateLastClassLoader.java
+++ b/core/src/main/java/org/lsposed/lspd/util/InMemoryDelegateLastClassLoader.java
@@ -6,22 +6,16 @@ import android.util.Log;
 
 import java.io.File;
 import java.io.IOException;
-import java.net.URL;
 import java.nio.ByteBuffer;
 import java.nio.channels.Channels;
 import java.util.ArrayList;
-import java.util.Enumeration;
 import java.util.zip.ZipFile;
 
-import dalvik.system.DelegateLastClassLoader;
 import hidden.ByteBufferDexClassLoader;
 
 public final class InMemoryDelegateLastClassLoader extends ByteBufferDexClassLoader {
-    private final DelegateLastClassLoader resources;
-
-    private InMemoryDelegateLastClassLoader(ByteBuffer[] dexBuffers, DelegateLastClassLoader resourcesClassLoader, String librarySearchPath, ClassLoader parent) {
+    public InMemoryDelegateLastClassLoader(ByteBuffer[] dexBuffers, String librarySearchPath, ClassLoader parent) {
         super(dexBuffers, librarySearchPath, parent);
-        resources = resourcesClassLoader;
     }
 
     @Override
@@ -48,16 +42,6 @@ public final class InMemoryDelegateLastClassLoader extends ByteBufferDexClassLoa
         }
     }
 
-    @Override
-    public URL getResource(String name) {
-        return resources.getResource(name);
-    }
-
-    @Override
-    public Enumeration<URL> getResources(String name) throws IOException {
-        return resources.getResources(name);
-    }
-
     public static InMemoryDelegateLastClassLoader loadApk(File apk, String librarySearchPath, ClassLoader parent) {
         var byteBuffers = new ArrayList<ByteBuffer>();
         try (var apkFile = new ZipFile(apk)) {
@@ -78,7 +62,6 @@ public final class InMemoryDelegateLastClassLoader extends ByteBufferDexClassLoa
             Log.e(TAG, "Can not open " + apk, e);
         }
         var dexBuffers = new ByteBuffer[byteBuffers.size()];
-        var resources = new DelegateLastClassLoader(apk.getPath(), librarySearchPath, parent);
-        return new InMemoryDelegateLastClassLoader(byteBuffers.toArray(dexBuffers), resources, librarySearchPath, parent);
+        return new InMemoryDelegateLastClassLoader(byteBuffers.toArray(dexBuffers), librarySearchPath, parent);
     }
 }

--- a/core/src/main/java/org/lsposed/lspd/util/InMemoryDelegateLastClassLoader.java
+++ b/core/src/main/java/org/lsposed/lspd/util/InMemoryDelegateLastClassLoader.java
@@ -1,0 +1,65 @@
+package org.lsposed.lspd.util;
+
+import static de.robv.android.xposed.XposedBridge.TAG;
+
+import android.util.Log;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.Channels;
+import java.util.ArrayList;
+import java.util.zip.ZipFile;
+
+import hidden.ByteBufferDexClassLoader;
+
+public final class InMemoryDelegateLastClassLoader extends ByteBufferDexClassLoader {
+    public InMemoryDelegateLastClassLoader(ByteBuffer[] dexBuffers, String librarySearchPath, ClassLoader parent) {
+        super(dexBuffers, librarySearchPath, parent);
+    }
+
+    @Override
+    protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+        Class<?> cl = findLoadedClass(name);
+        if (cl != null) {
+            return cl;
+        }
+        try {
+            //noinspection ConstantConditions
+            return Object.class.getClassLoader().loadClass(name);
+        } catch (ClassNotFoundException ignored) {
+        }
+        ClassNotFoundException fromSuper;
+        try {
+            return findClass(name);
+        } catch (ClassNotFoundException ex) {
+            fromSuper = ex;
+        }
+        try {
+            return getParent().loadClass(name);
+        } catch (ClassNotFoundException cnfe) {
+            throw fromSuper;
+        }
+    }
+
+    public static InMemoryDelegateLastClassLoader loadApk(File apk, String librarySearchPath, ClassLoader parent) {
+        var byteBuffers = new ArrayList<ByteBuffer>();
+        try (var apkFile = new ZipFile(apk)) {
+            int secondaryNumber = 2;
+            for (var dexFile = apkFile.getEntry("classes.dex"); dexFile != null;
+                 dexFile = apkFile.getEntry("classes" + secondaryNumber + ".dex"), secondaryNumber++) {
+                try (var in = apkFile.getInputStream(dexFile)) {
+                    var byteBuffer = ByteBuffer.allocate(in.available());
+                    Channels.newChannel(in).read(byteBuffer);
+                    byteBuffers.add(byteBuffer);
+                } catch (IOException e) {
+                    Log.w(TAG, "Can not read " + dexFile + " in " + apk, e);
+                }
+            }
+        } catch (IOException e) {
+            Log.e(TAG, "Can not open " + apk, e);
+        }
+        var dexBuffers = new ByteBuffer[byteBuffers.size()];
+        return new InMemoryDelegateLastClassLoader(byteBuffers.toArray(dexBuffers), librarySearchPath, parent);
+    }
+}

--- a/hiddenapi-bridge/src/main/java/hidden/ByteBufferDexClassLoader.java
+++ b/hiddenapi-bridge/src/main/java/hidden/ByteBufferDexClassLoader.java
@@ -1,0 +1,11 @@
+package hidden;
+
+import java.nio.ByteBuffer;
+
+import dalvik.system.BaseDexClassLoader;
+
+public class ByteBufferDexClassLoader extends BaseDexClassLoader {
+    public ByteBufferDexClassLoader(ByteBuffer[] dexFiles, String librarySearchPath, ClassLoader parent) {
+        super(dexFiles, librarySearchPath, parent);
+    }
+}

--- a/hiddenapi-stubs/src/main/java/dalvik/system/BaseDexClassLoader.java
+++ b/hiddenapi-stubs/src/main/java/dalvik/system/BaseDexClassLoader.java
@@ -7,10 +7,15 @@ package dalvik.system;
 
 import java.io.File;
 import java.net.URL;
+import java.nio.ByteBuffer;
 import java.util.Enumeration;
 
 public class BaseDexClassLoader extends ClassLoader {
     public BaseDexClassLoader(String dexPath, File optimizedDirectory, String librarySearchPath, ClassLoader parent) {
+        throw new RuntimeException("Stub!");
+    }
+
+    public BaseDexClassLoader(ByteBuffer[] dexFiles, String librarySearchPath, ClassLoader parent) {
         throw new RuntimeException("Stub!");
     }
 


### PR DESCRIPTION
Add API for loading modules in memory, the module path will not be shown in `/proc/pid/maps`, module can not use `ClassLoader.getResource()` to load resources.
When `assets/inmemory_xposed_init` exists, all dexes will be loaded into memory and parsing of `assets/xposed_init` will be skipped.