### PR TITLE
[gradle] Suppress applicationIdTextResource warning

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,7 +27,7 @@ buildscript {
     dependencies {
         classpath("com.android.tools.build:gradle:7.0.0-beta03")
         classpath("org.eclipse.jgit:org.eclipse.jgit:5.10.0.202012080955-r")
-        classpath("androidx.navigation:navigation-safe-args-gradle-plugin:2.3.5")
+        classpath("androidx.navigation:navigation-safe-args-gradle-plugin:2.4.0-alpha02")
         classpath(kotlin("gradle-plugin", version = "1.4.32"))
     }
 }


### PR DESCRIPTION
Safe-Args now depends on Android Gradle Plugin 4.2.0. This means you should no longer get the using applicationIdTextResource warning. (I6d67b, b/172824579)
