### PR TITLE
[core] Fix broadcast receiver after soft reboot

### DIFF
--- a/core/src/main/java/org/lsposed/lspd/service/BridgeService.java
+++ b/core/src/main/java/org/lsposed/lspd/service/BridgeService.java
@@ -94,7 +94,7 @@ public class BridgeService {
             bridgeService.unlinkToDeath(this, 0);
             bridgeService = null;
             listener.onSystemServerDied();
-            sendToBridge(serviceBinder, true);
+            new Thread(()-> sendToBridge(serviceBinder, true)).start();
         }
     };
 


### PR DESCRIPTION
`sendToBridge` stucks the binder thread so that
`ActivityManagerService`'s receipent won't be called

https://github.com/LSPosed/LSPosed/blob/547c512546f95d11f8f48b809e4c7a1e107a6891/core/src/main/java/org/lsposed/lspd/service/ActivityManagerService.java#L45-L55