### PR TITLE
[core] Compatible with applications with 32-bit native libraries only

### DIFF
--- a/core/src/main/java/de/robv/android/xposed/XposedInit.java
+++ b/core/src/main/java/de/robv/android/xposed/XposedInit.java
@@ -369,8 +369,15 @@ public final class XposedInit {
 
         // module can load it's own so
         StringBuilder nativePath = new StringBuilder();
-        for (String i : Build.SUPPORTED_ABIS) {
-            nativePath.append(apk).append("!/lib/").append(i).append(File.pathSeparator);
+        // Compatible with applications with 32-bit native libraries only
+        if (android.os.Process.is64Bit()) {
+           for (String i : Build.SUPPORTED_64_BIT_ABIS) {
+                nativePath.append(apk).append("!/lib/").append(i).append(File.pathSeparator);
+           }
+        } else {
+            for (String i : Build.SUPPORTED_32_BIT_ABIS) {
+                nativePath.append(apk).append("!/lib/").append(i).append(File.pathSeparator);
+            }
         }
         // Log.d(TAG, "Allowed native path" + nativePath.toString());
         ClassLoader initLoader = XposedInit.class.getClassLoader();


### PR DESCRIPTION
  if the target application with 32-bit native libraries only, we don't need 64-bit nativepath included