### PR TITLE
[core] AIDL array copy bug workaround

### DIFF
--- a/core/src/main/aidl/org/lsposed/lspd/service/ILSPApplicationService.aidl
+++ b/core/src/main/aidl/org/lsposed/lspd/service/ILSPApplicationService.aidl
@@ -3,7 +3,8 @@ package org.lsposed.lspd.service;
 interface ILSPApplicationService {
     IBinder requestModuleBinder();
 
-    boolean requestManagerBinder(String packageName, String path, out IBinder[] binder);
+    //TODO: after array copy bug fixed, use array instead of list
+    boolean requestManagerBinder(String packageName, String path, out List<IBinder> binder);
 
     boolean isResourcesHookEnabled();
 

--- a/core/src/main/java/org/lsposed/lspd/config/ApplicationServiceClient.java
+++ b/core/src/main/java/org/lsposed/lspd/config/ApplicationServiceClient.java
@@ -5,6 +5,7 @@ import android.os.ParcelFileDescriptor;
 
 import org.lsposed.lspd.service.ILSPApplicationService;
 
+import java.util.List;
 import java.util.Map;
 
 abstract public class ApplicationServiceClient implements ILSPApplicationService {
@@ -15,7 +16,7 @@ abstract public class ApplicationServiceClient implements ILSPApplicationService
     abstract public IBinder requestModuleBinder();
 
     @Override
-    abstract public boolean requestManagerBinder(String packageName, String path, IBinder[] binder);
+    abstract public boolean requestManagerBinder(String packageName, String path, List<IBinder> binder);
 
     @Override
     abstract public boolean isResourcesHookEnabled();

--- a/core/src/main/java/org/lsposed/lspd/config/LSPApplicationServiceClient.java
+++ b/core/src/main/java/org/lsposed/lspd/config/LSPApplicationServiceClient.java
@@ -27,6 +27,7 @@ import org.lsposed.lspd.service.ILSPApplicationService;
 import org.lsposed.lspd.util.Utils;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 public class LSPApplicationServiceClient extends ApplicationServiceClient {
@@ -68,7 +69,7 @@ public class LSPApplicationServiceClient extends ApplicationServiceClient {
     }
 
     @Override
-    public boolean requestManagerBinder(String packageName, String path, IBinder[] binder) {
+    public boolean requestManagerBinder(String packageName, String path, List<IBinder> binder) {
         try {
             return service.requestManagerBinder(packageName, path, binder);
         } catch (RemoteException | NullPointerException ignored) {

--- a/core/src/main/java/org/lsposed/lspd/hooker/LoadedApkGetCLHooker.java
+++ b/core/src/main/java/org/lsposed/lspd/hooker/LoadedApkGetCLHooker.java
@@ -32,6 +32,7 @@ import org.lsposed.lspd.util.Utils;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Map;
 
 import de.robv.android.xposed.XC_MethodHook;
@@ -90,7 +91,7 @@ public class LoadedApkGetCLHooker extends XC_MethodHook {
                 hookNewXSP(lpparam);
             }
 
-            var binder = new IBinder[1];
+            var binder = new ArrayList<IBinder>();
             var blocked = false;
             var info = loadedApk.getApplicationInfo();
             if (info != null) {
@@ -98,8 +99,8 @@ public class LoadedApkGetCLHooker extends XC_MethodHook {
                 var path = info.sourceDir;
                 blocked = serviceClient.requestManagerBinder(packageName, path, binder);
             }
-            if (binder[0] != null) {
-                InstallerVerifier.hookXposedInstaller(lpparam.classLoader, binder[0]);
+            if (binder.get(0) != null) {
+                InstallerVerifier.hookXposedInstaller(lpparam.classLoader, binder.get(0));
             } else if (blocked) {
                 InstallerVerifier.hookXposedInstaller(classLoader);
             } else {

--- a/core/src/main/java/org/lsposed/lspd/service/LSPApplicationService.java
+++ b/core/src/main/java/org/lsposed/lspd/service/LSPApplicationService.java
@@ -30,6 +30,7 @@ import android.util.Pair;
 import org.lsposed.lspd.util.InstallerVerifier;
 import org.lsposed.lspd.util.Utils;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -102,7 +103,7 @@ public class LSPApplicationService extends ILSPApplicationService.Stub {
     }
 
     @Override
-    public boolean requestManagerBinder(String packageName, String path, IBinder[] binder) throws RemoteException {
+    public boolean requestManagerBinder(String packageName, String path, List<IBinder> binder) throws RemoteException {
         ensureRegistered();
         if (ConfigManager.getInstance().isManager(getCallingUid()) &&
                 ConfigManager.getInstance().isManager(packageName) &&
@@ -111,7 +112,7 @@ public class LSPApplicationService extends ILSPApplicationService.Stub {
             if (Utils.isMIUI) {
                 service.new ManagerGuard(handles.get(getCallingPid()));
             }
-            binder[0] = service;
+            binder.add(service);
             return false;
         }
         return ConfigManager.getInstance().shouldBlock(packageName);


### PR DESCRIPTION
```java
      @Override public boolean requestManagerBinder(java.lang.String packageName, java.lang.String path, android.os.IBinder[] binder) throws android.os.RemoteException
      {
        android.os.Parcel _data = android.os.Parcel.obtain();
        android.os.Parcel _reply = android.os.Parcel.obtain();
        boolean _result;
        try {
          _data.writeInterfaceToken(DESCRIPTOR);
          _data.writeString(packageName);
          _data.writeString(path);
          if ((binder==null)) {
            _data.writeInt(-1);
          }
          else {
            _data.writeInt(binder.length);
          }
          boolean _status = mRemote.transact(Stub.TRANSACTION_requestManagerBinder, _data, _reply, 0);
          if (!_status) {
            if (getDefaultImpl() != null) {
              return getDefaultImpl().requestManagerBinder(packageName, path, binder);
            }
          }
          _reply.readException();
          _result = (0!=_reply.readInt());
          binder = _reply.createBinderArray();
        }
        finally {
          _reply.recycle();
          _data.recycle();
        }
        return _result;
      }
```

```diff
          _reply.readException();
          _result = (0!=_reply.readInt());
-          binder = _reply.createBinderArray();
+          android.os.IBinder[] array = _reply.createBinderArray();
+          System.arraycopy(array, 0, binder, 0, array.length);
        }
        finally {
```

But we can't edit the generated code.