### PR TITLE
[app] No need to keep EnclosingMethod when R8 full mode disabled

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -23,7 +23,7 @@
 
 # Gson uses generic type information stored in a class file when working with fields. Proguard
 # removes such information by default, so configure it to keep all of it.
--keepattributes Signature,InnerClasses,EnclosingMethod
+-keepattributes Signature,InnerClasses
 
 -dontwarn org.jetbrains.annotations.NotNull
 -dontwarn org.jetbrains.annotations.Nullable


### PR DESCRIPTION
It's required only when R8 full mode is enabled. 
Do NOT merge this until confirmed we cannot fix R8 full mode. Close #985 .