### PR TITLE
[core] Fix logcat tag len

### DIFF
--- a/core/src/main/cpp/daemon/logcat.cpp
+++ b/core/src/main/cpp/daemon/logcat.cpp
@@ -115,6 +115,10 @@ void Logcat::ProcessBuffer(struct log_msg *buf) {
     AndroidLogEntry entry;
     if (android_log_processLogBuffer(&buf->entry, &entry) < 0) return;
 
+    if (entry.tagLen >= 1 && entry.tag[entry.tagLen - 1] == '\0') [[likely]] {
+        --entry.tagLen;
+    }
+
     std::string_view tag(entry.tag, entry.tagLen);
     bool shortcut = false;
     if (tag == "LSPosed-Bridge"sv || tag == "XSharedPreferences"sv) [[unlikely]] {


### PR DESCRIPTION
It's an ASOP's bug that tag len is 1 larger