### PR TITLE
Fix `Post to channel` fails

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -109,9 +109,10 @@ jobs:
         CHANNEL_ID: ${{ secrets.CHANNEL_ID }}
         BOT_TOKEN: ${{ secrets.BOT_TOKEN }}
         COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
+        COMMIT_URL: ${{ github.event.head_commit.url }}
       run: |
         OUTPUT="core/release/"
         export release=$(find $OUTPUT -name "LSPosed-v*-release.zip")
         export debug=$(find $OUTPUT -name "LSPosed-v*-debug.zip")
-        ESCAPED=`python3 -c 'import json,os,urllib.parse; print(urllib.parse.quote(json.dumps(os.environ["COMMIT_MESSAGE"])))'`
+        ESCAPED=`python3 -c 'import json,os,urllib.parse; msg = os.environ["COMMIT_MESSAGE"]; print(urllib.parse.quote(json.dumps(msg if len(msg) <= 1024 else "[commit details]({})".format(os.environ["COMMIT_URL"]))))'`
         curl -v "https://api.telegram.org/bot${BOT_TOKEN}/sendMediaGroup?chat_id=${CHANNEL_ID}&media=%5B%7B%22type%22:%22document%22,%20%22media%22:%22attach://release%22%7D,%7B%22type%22:%22document%22,%20%22media%22:%22attach://debug%22,%22caption%22:${ESCAPED}%7D%5D"  -F release="@$release" -F debug="@$debug"

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -114,5 +114,5 @@ jobs:
         OUTPUT="core/release/"
         export release=$(find $OUTPUT -name "LSPosed-v*-release.zip")
         export debug=$(find $OUTPUT -name "LSPosed-v*-debug.zip")
-        ESCAPED=`python3 -c 'import json,os,urllib.parse; msg = os.environ["COMMIT_MESSAGE"]; print(urllib.parse.quote(json.dumps(msg if len(msg) <= 1024 else os.environ["COMMIT_URL"])))'`
+        ESCAPED=`python3 -c 'import json,os,urllib.parse; msg = json.dumps(os.environ["COMMIT_MESSAGE"]); print(urllib.parse.quote(msg if len(msg) <= 1024 else json.dumps(os.environ["COMMIT_URL"])))'`
         curl -v "https://api.telegram.org/bot${BOT_TOKEN}/sendMediaGroup?chat_id=${CHANNEL_ID}&media=%5B%7B%22type%22:%22document%22,%20%22media%22:%22attach://release%22%7D,%7B%22type%22:%22document%22,%20%22media%22:%22attach://debug%22,%22caption%22:${ESCAPED}%7D%5D"  -F release="@$release" -F debug="@$debug"

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -114,5 +114,5 @@ jobs:
         OUTPUT="core/release/"
         export release=$(find $OUTPUT -name "LSPosed-v*-release.zip")
         export debug=$(find $OUTPUT -name "LSPosed-v*-debug.zip")
-        ESCAPED=`python3 -c 'import json,os,urllib.parse; msg = os.environ["COMMIT_MESSAGE"]; print(urllib.parse.quote(json.dumps(msg if len(msg) <= 1024 else "[commit details]({})".format(os.environ["COMMIT_URL"]))))'`
+        ESCAPED=`python3 -c 'import json,os,urllib.parse; msg = os.environ["COMMIT_MESSAGE"]; print(urllib.parse.quote(json.dumps(msg if len(msg) <= 1024 else os.environ["COMMIT_URL"])))'`
         curl -v "https://api.telegram.org/bot${BOT_TOKEN}/sendMediaGroup?chat_id=${CHANNEL_ID}&media=%5B%7B%22type%22:%22document%22,%20%22media%22:%22attach://release%22%7D,%7B%22type%22:%22document%22,%20%22media%22:%22attach://debug%22,%22caption%22:${ESCAPED}%7D%5D"  -F release="@$release" -F debug="@$debug"


### PR DESCRIPTION
Omit commit messages if length exceeds 1024, replace it with a commit URL