### PR TITLE
[app] generate at runtime list of languages supported by app

### DIFF
--- a/app/src/main/java/org/lsposed/manager/ui/fragment/SettingsFragment.java
+++ b/app/src/main/java/org/lsposed/manager/ui/fragment/SettingsFragment.java
@@ -256,7 +256,7 @@ public class SettingsFragment extends BaseFragment {
                 var entries = new ArrayList<CharSequence>();
                 entries.add(language.getEntries()[0]);
                 var lstLang = getAppLanguages(getContext(), R.string.Settings);
-                for(var lang : lstLang) {
+                for (var lang : lstLang) {
                     var locale = Locale.forLanguageTag(lang);
                     entries.add(HtmlCompat.fromHtml(String.format("%s - %s",
                             !TextUtils.isEmpty(locale.getScript()) ? locale.getDisplayScript(locale) : locale.getDisplayName(locale),
@@ -316,13 +316,13 @@ public class SettingsFragment extends BaseFragment {
             var lstLang = new ArrayList<String>();
             lstLang.add(Locale.ENGLISH.getLanguage());
 
-            for(String loc : ctx.getAssets().getLocales()) {
-                if(loc.isEmpty()) {
+            for (String loc : ctx.getAssets().getLocales()) {
+                if (loc.isEmpty()) {
                     continue;
                 }
                 Locale locale = Locale.forLanguageTag(loc);
                 conf.setLocale(locale);
-                if(!lstLang.contains(loc) && !reference.equals(ctx.createConfigurationContext(conf).getString(id))) {
+                if (!lstLang.contains(loc) && !reference.equals(ctx.createConfigurationContext(conf).getString(id))) {
                     lstLang.add(loc);
                 }
             }

--- a/app/src/main/java/org/lsposed/manager/ui/fragment/SettingsFragment.java
+++ b/app/src/main/java/org/lsposed/manager/ui/fragment/SettingsFragment.java
@@ -20,6 +20,7 @@
 package org.lsposed.manager.ui.fragment;
 
 import android.content.Context;
+import android.content.res.Configuration;
 import android.os.Build;
 import android.os.Bundle;
 import android.provider.Settings;
@@ -137,6 +138,8 @@ public class SettingsFragment extends BaseFragment {
 
         @Override
         public void onCreatePreferencesFix(Bundle savedInstanceState, String rootKey) {
+            final String SYSTEM = "SYSTEM";
+
             addPreferencesFromResource(R.xml.prefs);
 
             boolean installed = ConfigManager.isBinderAlive();
@@ -240,7 +243,7 @@ public class SettingsFragment extends BaseFragment {
             SimpleMenuPreference language = findPreference("language");
             if (language != null) {
                 language.setOnPreferenceChangeListener((preference, newValue) -> {
-                    var locale = "SYSTEM".equals(newValue) ? LocaleDelegate.getSystemLocale() : Locale.forLanguageTag((String) newValue);
+                    var locale = SYSTEM.equals(newValue) ? LocaleDelegate.getSystemLocale() : Locale.forLanguageTag((String) newValue);
                     LocaleDelegate.setDefaultLocale(locale);
                     MainActivity activity = (MainActivity) getActivity();
                     if (activity != null) {
@@ -251,19 +254,19 @@ public class SettingsFragment extends BaseFragment {
                 var tag = language.getValue();
                 var userLocale = App.getLocale();
                 var entries = new ArrayList<CharSequence>();
-                for (int i = 0; i < language.getEntries().length; i++) {
-                    if (i > 0) {
-                        var locale = Locale.forLanguageTag(language.getEntries()[i].toString());
-                        entries.add(HtmlCompat.fromHtml(String.format("%s - %s",
-                                !TextUtils.isEmpty(locale.getScript()) ? locale.getDisplayScript(locale) : locale.getDisplayName(locale),
-                                !TextUtils.isEmpty(locale.getScript()) ? locale.getDisplayScript(userLocale) : locale.getDisplayName(userLocale)
-                        ), HtmlCompat.FROM_HTML_MODE_LEGACY));
-                    } else {
-                        entries.add(language.getEntries()[i]);
-                    }
+                entries.add(language.getEntries()[0]);
+                var lstLang = getAppLanguages(getContext(), R.string.Settings);
+                for(var lang : lstLang) {
+                    var locale = Locale.forLanguageTag(lang);
+                    entries.add(HtmlCompat.fromHtml(String.format("%s - %s",
+                            !TextUtils.isEmpty(locale.getScript()) ? locale.getDisplayScript(locale) : locale.getDisplayName(locale),
+                            !TextUtils.isEmpty(locale.getScript()) ? locale.getDisplayScript(userLocale) : locale.getDisplayName(userLocale)
+                    ), HtmlCompat.FROM_HTML_MODE_LEGACY));
                 }
                 language.setEntries(entries.toArray(new CharSequence[0]));
-                if (TextUtils.isEmpty(tag) || "SYSTEM".equals(tag)) {
+                lstLang.add(0, SYSTEM);
+                language.setEntryValues(lstLang.toArray(new CharSequence[0]));
+                if (TextUtils.isEmpty(tag) || SYSTEM.equals(tag)) {
                     language.setSummary(getString(rikka.material.R.string.follow_system));
                 } else {
                     var locale = Locale.forLanguageTag(tag);
@@ -302,6 +305,30 @@ public class SettingsFragment extends BaseFragment {
                 }
             });
             return recyclerView;
+        }
+
+        private ArrayList<String> getAppLanguages(Context ctx, int id) {
+            Configuration conf = ctx.getResources().getConfiguration();
+            Locale originalLocale = conf.getLocales().get(0);
+            conf.setLocale(Locale.ENGLISH);
+            final String reference = ctx.createConfigurationContext(conf).getString(id);
+
+            var lstLang = new ArrayList<String>();
+            lstLang.add(Locale.ENGLISH.getLanguage());
+
+            for(String loc : ctx.getAssets().getLocales()) {
+                if(loc.isEmpty()) {
+                    continue;
+                }
+                Locale locale = Locale.forLanguageTag(loc);
+                conf.setLocale(locale);
+                var sLang = locale.getLanguage();
+                if(!lstLang.contains(sLang) && !reference.equals(ctx.createConfigurationContext(conf).getString(id))) {
+                    lstLang.add(sLang);
+                }
+            }
+            conf.setLocale(originalLocale);
+            return lstLang;
         }
     }
 

--- a/app/src/main/java/org/lsposed/manager/ui/fragment/SettingsFragment.java
+++ b/app/src/main/java/org/lsposed/manager/ui/fragment/SettingsFragment.java
@@ -322,9 +322,8 @@ public class SettingsFragment extends BaseFragment {
                 }
                 Locale locale = Locale.forLanguageTag(loc);
                 conf.setLocale(locale);
-                var sLang = locale.getLanguage();
-                if(!lstLang.contains(sLang) && !reference.equals(ctx.createConfigurationContext(conf).getString(id))) {
-                    lstLang.add(sLang);
+                if(!lstLang.contains(loc) && !reference.equals(ctx.createConfigurationContext(conf).getString(id))) {
+                    lstLang.add(loc);
                 }
             }
             conf.setLocale(originalLocale);

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -34,65 +34,6 @@
 
     <string-array name="language" translatable="false">
         <item>@string/follow_system</item>
-        <item>af</item>
-        <item>ar</item>
-        <item>ca</item>
-        <item>cs</item>
-        <item>da</item>
-        <item>el</item>
-        <item>en</item>
-        <item>es</item>
-        <item>fi</item>
-        <item>fr</item>
-        <item>hu</item>
-        <item>it</item>
-        <item>iw</item>
-        <item>ja</item>
-        <item>ko</item>
-        <item>nl</item>
-        <item>no</item>
-        <item>pl</item>
-        <item>pt-BR</item>
-        <item>pt-PT</item>
-        <item>ro</item>
-        <item>ru</item>
-        <item>tr</item>
-        <item>uk</item>
-        <item>vi</item>
-        <item>zh-CN</item>
-        <item>zh-HK</item>
-        <item>zh-TW</item>
     </string-array>
 
-    <string-array name="language_value" translatable="false">
-        <item>SYSTEM</item>
-        <item>af</item>
-        <item>ar</item>
-        <item>ca</item>
-        <item>cs</item>
-        <item>da</item>
-        <item>el</item>
-        <item>en</item>
-        <item>es</item>
-        <item>fi</item>
-        <item>fr</item>
-        <item>hu</item>
-        <item>it</item>
-        <item>iw</item>
-        <item>ja</item>
-        <item>ko</item>
-        <item>nl</item>
-        <item>no</item>
-        <item>pl</item>
-        <item>pt-BR</item>
-        <item>pt-PT</item>
-        <item>ro</item>
-        <item>ru</item>
-        <item>tr</item>
-        <item>uk</item>
-        <item>vi</item>
-        <item>zh-CN</item>
-        <item>zh-HK</item>
-        <item>zh-TW</item>
-    </string-array>
 </resources>

--- a/app/src/main/res/xml-v29/prefs.xml
+++ b/app/src/main/res/xml-v29/prefs.xml
@@ -34,7 +34,6 @@
         <rikka.preference.SimpleMenuPreference
             android:defaultValue="SYSTEM"
             android:entries="@array/language"
-            android:entryValues="@array/language_value"
             android:icon="@drawable/ic_baseline_translate_24"
             android:summary="%s"
             android:key="language"

--- a/app/src/main/res/xml/prefs.xml
+++ b/app/src/main/res/xml/prefs.xml
@@ -35,7 +35,6 @@
         <rikka.preference.SimpleMenuPreference
             android:defaultValue="SYSTEM"
             android:entries="@array/language"
-            android:entryValues="@array/language_value"
             android:icon="@drawable/ic_baseline_translate_24"
             android:summary="%s"
             android:key="language"


### PR DESCRIPTION
When a language is added no need update arrays in preference.
For example after the language fa has been added this doesn't exist in the listpreference.

I don't know if is better move the method getAppLanguages in some class org.lsposed.manager.util
Maybe is better remove also the array string-array language and add @string/follow_system programmatically to entries
