### PR TITLE
[core] Clear ProfilingInfo in backup method

### DIFF
--- a/core/src/main/cpp/external/yahfa/include/HookMain.h
+++ b/core/src/main/cpp/external/yahfa/include/HookMain.h
@@ -17,7 +17,7 @@ namespace yahfa {
 
     jboolean backupAndHookNative(JNIEnv *env, jclass clazz,
                                  jobject target, jobject hook,
-                                 jobject backup);
+                                 jobject backup, jboolean clearData);
 
     void *getArtMethod(JNIEnv *env, jobject jmethod);
 

--- a/core/src/main/cpp/external/yahfa/src/HookMain.cpp
+++ b/core/src/main/cpp/external/yahfa/src/HookMain.cpp
@@ -9,6 +9,7 @@
 
 int SDKVersion;
 size_t OFFSET_entry_point_from_quick_compiled_code_in_ArtMethod;
+size_t OFFSET_data_in_ArtMethod;
 
 namespace yahfa {
     namespace {
@@ -57,7 +58,7 @@ namespace yahfa {
             }
         }
 
-        int doBackupAndHook(void *targetMethod, void *hookMethod, void *backupMethod) {
+        int doBackupAndHook(void *targetMethod, void *hookMethod, void *backupMethod, bool clearData) {
             LOGI("target method is at %p, hook method is at %p, backup method is at %p",
                  targetMethod, hookMethod, backupMethod);
 
@@ -101,6 +102,9 @@ namespace yahfa {
                 setAccessFlags(targetMethod, access_flags);
             }
 
+            if (clearData) 
+                writeAddr((char *) targetMethod + OFFSET_data_in_ArtMethod, nullptr);
+
             LOGI("hook and backup done");
             return 0;
         }
@@ -136,6 +140,7 @@ namespace yahfa {
                 LOGE("not compatible with SDK %d", sdkVersion);
                 break;
         }
+        OFFSET_data_in_ArtMethod = OFFSET_entry_point_from_quick_compiled_code_in_ArtMethod - pointer_size;
 
         setupTrampoline();
     }
@@ -186,11 +191,12 @@ namespace yahfa {
 
     jboolean backupAndHookNative(JNIEnv *env, [[maybe_unused]] jclass clazz,
                                  jobject target, jobject hook,
-                                 jobject backup) {
+                                 jobject backup, jboolean clearData) {
 
         if (!doBackupAndHook(getArtMethod(env, target),
                              getArtMethod(env, hook),
-                             getArtMethod(env, backup)
+                             getArtMethod(env, backup),
+                             clearData == JNI_TRUE
         )) {
             env->NewGlobalRef(hook); // keep a global ref so that the hook method would not be GCed
             if (backup) env->NewGlobalRef(backup);

--- a/core/src/main/cpp/external/yahfa/src/HookMain.cpp
+++ b/core/src/main/cpp/external/yahfa/src/HookMain.cpp
@@ -103,7 +103,7 @@ namespace yahfa {
             }
 
             if (clearData) 
-                writeAddr((char *) targetMethod + OFFSET_data_in_ArtMethod, nullptr);
+                writeAddr((char *) backupMethod + OFFSET_data_in_ArtMethod, nullptr);
 
             LOGI("hook and backup done");
             return 0;
@@ -189,7 +189,7 @@ namespace yahfa {
         return ret;
     }
 
-    jboolean backupAndHookNative(JNIEnv *env, [[maybe_unused]] jclass clazz,
+    jboolean backupAndHookNative(JNIEnv *env, jclass,
                                  jobject target, jobject hook,
                                  jobject backup, jboolean clearData) {
 

--- a/core/src/main/cpp/main/src/jni/yahfa.cpp
+++ b/core/src/main/cpp/main/src/jni/yahfa.cpp
@@ -42,12 +42,12 @@ namespace lspd {
     }
 
     LSP_DEF_NATIVE_METHOD(jboolean, Yahfa, backupAndHookNative, jobject target,
-                          jobject hook, jobject backup) {
+                          jobject hook, jobject backup, jboolean clearData) {
         art::gc::ScopedGCCriticalSection section(art::Thread::Current().Get(),
                                                  art::gc::kGcCauseDebugger,
                                                  art::gc::kCollectorTypeDebugger);
         art::thread_list::ScopedSuspendAll suspend("Yahfa Hook", false);
-        return yahfa::backupAndHookNative(env, clazz, target, hook, backup);
+        return yahfa::backupAndHookNative(env, clazz, target, hook, backup, clearData);
     }
 
     LSP_DEF_NATIVE_METHOD(void, Yahfa, recordHooked, jobject member) {
@@ -172,7 +172,7 @@ namespace lspd {
             LSP_NATIVE_METHOD(Yahfa, findMethodNative,
                               "(Ljava/lang/Class;Ljava/lang/String;Ljava/lang/String;)Ljava/lang/reflect/Executable;"),
             LSP_NATIVE_METHOD(Yahfa, backupAndHookNative,
-                              "(Ljava/lang/reflect/Executable;Ljava/lang/reflect/Method;Ljava/lang/reflect/Method;)Z"),
+                              "(Ljava/lang/reflect/Executable;Ljava/lang/reflect/Method;Ljava/lang/reflect/Method;Z)Z"),
             LSP_NATIVE_METHOD(Yahfa, recordHooked, "(Ljava/lang/reflect/Executable;)V"),
             LSP_NATIVE_METHOD(Yahfa, isHooked, "(Ljava/lang/reflect/Executable;)Z"),
             LSP_NATIVE_METHOD(Yahfa, buildHooker,

--- a/core/src/main/java/org/lsposed/lspd/core/yahfa/HookMain.java
+++ b/core/src/main/java/org/lsposed/lspd/core/yahfa/HookMain.java
@@ -27,6 +27,7 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.Executable;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
+import java.lang.reflect.Proxy;
 import java.util.ArrayList;
 import java.util.Arrays;
 

--- a/core/src/main/java/org/lsposed/lspd/core/yahfa/HookMain.java
+++ b/core/src/main/java/org/lsposed/lspd/core/yahfa/HookMain.java
@@ -51,7 +51,11 @@ public class HookMain {
             // backup is just a placeholder and the constraint could be less strict
             checkCompatibleMethods(target, backup, "Backup");
         }
-        if(!Yahfa.backupAndHookNative(target, hook, backup)){
+        // Since Android 7.0, the data_ member is used to save a profiling info which used for optimizing
+        // This may cause some crashes, clear the member to avoid it
+        // Note that this cannot be applied to native and proxy methods as their data_ member has been used for other purposes
+        boolean clearData = !(Modifiers.isNative(target.getModifiers()) || Proxy.isProxyClass(target.getDeclaringClass()));
+        if(!Yahfa.backupAndHookNative(target, hook, backup, clearData)) {
             throw new RuntimeException("Failed to hook " + target + " with " + hook);
         } else {
             Yahfa.recordHooked(target);

--- a/core/src/main/java/org/lsposed/lspd/core/yahfa/HookMain.java
+++ b/core/src/main/java/org/lsposed/lspd/core/yahfa/HookMain.java
@@ -55,7 +55,7 @@ public class HookMain {
         // Since Android 7.0, the data_ member is used to save a profiling info which used for optimizing
         // This may cause some crashes, clear the member to avoid it
         // Note that this cannot be applied to native and proxy methods as their data_ member has been used for other purposes
-        boolean clearData = !(Modifiers.isNative(target.getModifiers()) || Proxy.isProxyClass(target.getDeclaringClass()));
+        boolean clearData = !(Modifier.isNative(target.getModifiers()) || Proxy.isProxyClass(target.getDeclaringClass()));
         if(!Yahfa.backupAndHookNative(target, hook, backup, clearData)) {
             throw new RuntimeException("Failed to hook " + target + " with " + hook);
         } else {

--- a/core/src/main/java/org/lsposed/lspd/nativebridge/Yahfa.java
+++ b/core/src/main/java/org/lsposed/lspd/nativebridge/Yahfa.java
@@ -25,7 +25,7 @@ import java.lang.reflect.Method;
 
 public class Yahfa {
 
-    public static native boolean backupAndHookNative(Executable target, Method hook, Method backup);
+    public static native boolean backupAndHookNative(Executable target, Method hook, Method backup, boolean clearData);
 
     // JNI.ToReflectedMethod() could return either Method or Constructor
     public static native Executable findMethodNative(Class<?> targetClass, String methodName, String methodSig);


### PR DESCRIPTION
The data_ member is used to save a profiling info which used for optimizing and may cause some crashes. Just clear the member to avoid this.
Edit and commit in web editor, not tested. Please test before merging.
May fix #1144 