### PR TITLE
Fix for #1250

### DIFF
--- a/app/src/main/java/org/lsposed/manager/ui/fragment/SettingsFragment.java
+++ b/app/src/main/java/org/lsposed/manager/ui/fragment/SettingsFragment.java
@@ -21,6 +21,7 @@ package org.lsposed.manager.ui.fragment;
 
 import android.content.Context;
 import android.content.res.Configuration;
+import android.content.res.Resources.NotFoundException;
 import android.os.Build;
 import android.os.Bundle;
 import android.provider.Settings;
@@ -321,10 +322,16 @@ public class SettingsFragment extends BaseFragment {
             Configuration conf = ctx.getResources().getConfiguration();
             Locale originalLocale = conf.getLocales().get(0);
             conf.setLocale(Locale.ENGLISH);
-            final String reference = ctx.createConfigurationContext(conf).getString(id);
 
             var lstLang = new ArrayList<String>();
             lstLang.add(Locale.ENGLISH.getLanguage());
+
+            final String reference;
+            try {
+                reference = ctx.createConfigurationContext(conf).getString(id);
+            } catch(NotFoundException nfe) {
+                return lstLang; // return only english
+            }
 
             for (String loc : ctx.getAssets().getLocales()) {
                 if (loc.isEmpty()) {


### PR DESCRIPTION
Is not a real fix but only a workaround. I can't reproduce the issue.
If the resource Settings is not found, return only an arraylist with english, so in the list of avaiable languages will be only "Follow the system" and "English"