### PR TITLE
[core] Move `setActivityController` to boot complete

### DIFF
--- a/core/src/main/java/org/lsposed/lspd/service/ActivityManagerService.java
+++ b/core/src/main/java/org/lsposed/lspd/service/ActivityManagerService.java
@@ -63,7 +63,8 @@ public class ActivityManagerService {
             try {
                 binder.linkToDeath(deathRecipient, 0);
                 am = IActivityManager.Stub.asInterface(binder);
-                am.setActivityController(null, false);
+                // For oddo Android 9 we cannot set activity controller here...
+                // am.setActivityController(null, false);
             } catch (RemoteException e) {
                 Log.e(TAG, Log.getStackTraceString(e));
             }


### PR DESCRIPTION
For oddo Android 9, if activityController is set too earilier, it
crashes system server. So move the set latter