### PR TITLE
Use cmake 3.21+

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -59,9 +59,9 @@ jobs:
           daemon/build/.lto-cache
         key: native-cache-${{ github.sha }}
         restore-keys: native-cache-
-    - name: Install ccache
+    - name: Install dep
       run: |
-        sudo apt-get install -y ccache
+        sudo apt-get install -y ccache ninja-build
         ccache -o max_size=1G
         ccache -o hash_dir=false
         ccache -o compiler_check='%compiler% -dumpmachine; %compiler% -dumpversion'
@@ -75,6 +75,8 @@ jobs:
         echo 'org.gradle.vfs.watch=true' >> gradle.properties
         echo 'org.gradle.jvmargs=-Xmx2048m' >> gradle.properties
         echo 'android.native.buildOutput=verbose' >> gradle.properties
+        ln -s $(which ninja) $(dirname $(which cmake)) # https://issuetracker.google.com/issues/206099937
+        echo "cmake.dir=$(dirname $(dirname $(which cmake)))" >> local.properties
         ./gradlew zipAll
         ccache -s
     - name: Prepare artifact


### PR DESCRIPTION
This can get rid of legacy cmake config which always adds `-g` to build and thus reduce the size of debug build.