### PR TITLE
No need to implement Method.invoke ourselves

### DIFF
--- a/core/src/main/java/org/lsposed/lspd/nativebridge/HookBridge.java
+++ b/core/src/main/java/org/lsposed/lspd/nativebridge/HookBridge.java
@@ -11,9 +11,7 @@ public class HookBridge {
 
     public static native boolean deoptimizeMethod(Executable method);
 
-    @FastNative
     public static native Object invokeOriginalMethod(Executable method, Object thisObject, Object... args) throws IllegalAccessException, IllegalArgumentException, InvocationTargetException;
 
-    @FastNative
     public static native boolean instanceOf(Object obj, Class<?> clazz);
 }

--- a/core/src/main/java/org/lsposed/lspd/nativebridge/HookBridge.java
+++ b/core/src/main/java/org/lsposed/lspd/nativebridge/HookBridge.java
@@ -13,5 +13,6 @@ public class HookBridge {
 
     public static native Object invokeOriginalMethod(Executable method, Object thisObject, Object... args) throws IllegalAccessException, IllegalArgumentException, InvocationTargetException;
 
+    @FastNative
     public static native boolean instanceOf(Object obj, Class<?> clazz);
 }

--- a/core/src/main/jni/src/jni/hook_bridge.cpp
+++ b/core/src/main/jni/src/jni/hook_bridge.cpp
@@ -38,8 +38,7 @@ std::shared_mutex hooked_lock;
 // Rehashing invalidates iterators, changes ordering between elements, and changes which buckets elements appear in, but does not invalidate pointers or references to elements.
 std::unordered_map<jmethodID, HookItem> hooked_methods;
 
-jobject (*native_invoke)(JNIEnv* env, jobject javaMethod, jobject javaReceiver,
-                          jobjectArray javaArgs);
+jmethodID invoke = nullptr;
 }
 
 namespace lspd {
@@ -184,11 +183,9 @@ static JNINativeMethod gMethods[] = {
 
 void RegisterHookBridge(JNIEnv *env) {
     auto method = env->FindClass("java/lang/reflect/Method");
-    auto invoke = env->GetMethodID(
+    invoke = env->GetMethodID(
             method, "invoke",
             "(Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/Object;");
-    native_invoke = reinterpret_cast<decltype(native_invoke)>(
-            lsplant::GetNativeFunction(env, env->ToReflectedMethod(method, invoke, false)));
     env->DeleteLocalRef(method);
     REGISTER_LSP_NATIVE_METHODS(HookBridge);
 }

--- a/core/src/main/jni/src/jni/hook_bridge.cpp
+++ b/core/src/main/jni/src/jni/hook_bridge.cpp
@@ -166,7 +166,7 @@ LSP_DEF_NATIVE_METHOD(jobject, HookBridge, invokeOriginalMethod, jobject hookMet
     if (hook_item && hook_item->backup) {
         to_call = hook_item->backup;
     }
-    return native_invoke(env, to_call, thiz, args);
+    return env->CallObjectMethod(to_call, invoke, thiz, args);
 }
 
 LSP_DEF_NATIVE_METHOD(jboolean, HookBridge, instanceOf, jobject object, jclass expected_class) {


### PR DESCRIPTION
Since we have prevented Method.invoke() being hooked, directly calling Method.invoke() is safe.