### PR TITLE
Fix the notification push issue after Xposed Module installation or removed

### DIFF
--- a/daemon/src/main/java/org/lsposed/lspd/service/LSPManagerService.java
+++ b/daemon/src/main/java/org/lsposed/lspd/service/LSPManagerService.java
@@ -223,11 +223,8 @@ public class LSPManagerService extends ILSPManagerService.Stub {
         }
     }
 
-    private static String getNotificationIdKey(String modulePackageName,
-                                               int moduleUserId,
-                                               boolean enabled,
-                                               boolean systemModule) {
-        return modulePackageName + ":" + moduleUserId + ":" + enabled + ":" + systemModule;
+    private static String getNotificationIdKey(String modulePackageName, int moduleUserId) {
+        return modulePackageName + ":" + moduleUserId;
     }
 
     private static int getAutoIncrementNotificationId() {
@@ -251,11 +248,8 @@ public class LSPManagerService extends ILSPManagerService.Stub {
         else return idValue;
     }
 
-    private static int pushAndGetNotificationId(String modulePackageName,
-                                                int moduleUserId,
-                                                boolean enabled,
-                                                boolean systemModule) {
-        var idKey = getNotificationIdKey(modulePackageName, moduleUserId, enabled, systemModule);
+    private static int pushAndGetNotificationId(String modulePackageName, int moduleUserId) {
+        var idKey = getNotificationIdKey(modulePackageName, moduleUserId);
         var idValue = getAutoIncrementNotificationId();
         notificationIds.putIfAbsent(idKey, idValue);
         return idValue;
@@ -295,19 +289,16 @@ public class LSPManagerService extends ILSPManagerService.Stub {
             im.createNotificationChannels("android",
                     new android.content.pm.ParceledListSlice<>(Collections.singletonList(channel)));
             im.enqueueNotificationWithTag("android", "android", modulePackageName,
-                    pushAndGetNotificationId(modulePackageName, moduleUserId, enabled, systemModule),
+                    pushAndGetNotificationId(modulePackageName, moduleUserId),
                     notification, 0);
         } catch (Throwable e) {
             Log.e(TAG, "post notification", e);
         }
     }
 
-    public static void cancelNotification(String modulePackageName,
-                                          int moduleUserId,
-                                          boolean enabled,
-                                          boolean systemModule) {
+    public static void cancelNotification(String modulePackageName, int moduleUserId) {
         try {
-            var idKey = getNotificationIdKey(modulePackageName, moduleUserId, enabled, systemModule);
+            var idKey = getNotificationIdKey(modulePackageName, moduleUserId);
             var notificationId = notificationIds.get(idKey);
             if (notificationId == null) return;
             var im = INotificationManager.Stub.asInterface(android.os.ServiceManager.getService("notification"));

--- a/daemon/src/main/java/org/lsposed/lspd/service/LSPManagerService.java
+++ b/daemon/src/main/java/org/lsposed/lspd/service/LSPManagerService.java
@@ -234,6 +234,7 @@ public class LSPManagerService extends ILSPManagerService.Stub {
         // previousNotificationId start with 2001
         var idValue = previousNotificationId++;
         // Templates that may conflict with system ids after 2000
+        // Copied from https://android.googlesource.com/platform/frameworks/base/+/master/proto/src/system_messages.proto
         var NOTE_NETWORK_AVAILABLE = 17303299;
         var NOTE_REMOTE_BUGREPORT = 678432343;
         var NOTE_STORAGE_PUBLIC = 0x53505542;

--- a/daemon/src/main/java/org/lsposed/lspd/service/LSPManagerService.java
+++ b/daemon/src/main/java/org/lsposed/lspd/service/LSPManagerService.java
@@ -244,8 +244,11 @@ public class LSPManagerService extends ILSPManagerService.Stub {
                 idValue == NOTE_STORAGE_PUBLIC ||
                 idValue == NOTE_STORAGE_PRIVATE ||
                 idValue == NOTE_STORAGE_DISK ||
-                idValue == NOTE_STORAGE_MOVE) return getAutoIncrementNotificationId();
-        else return idValue;
+                idValue == NOTE_STORAGE_MOVE) {
+            return getAutoIncrementNotificationId();
+        } else {
+            return idValue;
+        }
     }
 
     private static int pushAndGetNotificationId(String modulePackageName, int moduleUserId) {

--- a/daemon/src/main/java/org/lsposed/lspd/service/LSPManagerService.java
+++ b/daemon/src/main/java/org/lsposed/lspd/service/LSPManagerService.java
@@ -259,6 +259,15 @@ public class LSPManagerService extends ILSPManagerService.Stub {
         }
     }
 
+    public static void cancelNotification() {
+        try {
+            var im = INotificationManager.Stub.asInterface(android.os.ServiceManager.getService("notification"));
+            im.cancelNotificationWithTag("android", "android", "114514", NOTIFICATION_ID, 0);
+        } catch (Throwable e) {
+            Log.e(TAG, "cancel notification", e);
+        }
+    }
+
     @SuppressLint("WrongConstant")
     public static void broadcastIntent(Intent inIntent) {
         var intent = new Intent("org.lsposed.manager.NOTIFICATION");

--- a/daemon/src/main/java/org/lsposed/lspd/service/LSPManagerService.java
+++ b/daemon/src/main/java/org/lsposed/lspd/service/LSPManagerService.java
@@ -236,7 +236,7 @@ public class LSPManagerService extends ILSPManagerService.Stub {
                                                 boolean systemModule) {
         var idKey = getNotificationIdKey(modulePackageName, moduleUserId, enabled, systemModule);
         var idValue = idKey.hashCode();
-        notificationIds.put(idKey, idValue);
+        notificationIds.putIfAbsent(idKey, idValue);
         return idValue;
     }
 

--- a/daemon/src/main/java/org/lsposed/lspd/service/LSPManagerService.java
+++ b/daemon/src/main/java/org/lsposed/lspd/service/LSPManagerService.java
@@ -93,6 +93,7 @@ public class LSPManagerService extends ILSPManagerService.Stub {
     public static final int CHANNEL_IMP = NotificationManager.IMPORTANCE_HIGH;
 
     private static final HashMap<String, Integer> notificationIds = new HashMap<>();
+    private static int previousNotificationId = 2000;
 
     private static final HandlerThread worker = new HandlerThread("manager worker");
     private static final Handler workerHandler;
@@ -229,12 +230,32 @@ public class LSPManagerService extends ILSPManagerService.Stub {
         return modulePackageName + ":" + moduleUserId + ":" + enabled + ":" + systemModule;
     }
 
+    private static int getAutoIncrementNotificationId() {
+        // previousNotificationId start with 2001
+        var idValue = previousNotificationId++;
+        // Templates that may conflict with system ids after 2000
+        var NOTE_NETWORK_AVAILABLE = 17303299;
+        var NOTE_REMOTE_BUGREPORT = 678432343;
+        var NOTE_STORAGE_PUBLIC = 0x53505542;
+        var NOTE_STORAGE_PRIVATE = 0x53505256;
+        var NOTE_STORAGE_DISK = 0x5344534b;
+        var NOTE_STORAGE_MOVE = 0x534d4f56;
+        // If auto created id is conflict, recreate it
+        if (idValue == NOTE_NETWORK_AVAILABLE ||
+                idValue == NOTE_REMOTE_BUGREPORT ||
+                idValue == NOTE_STORAGE_PUBLIC ||
+                idValue == NOTE_STORAGE_PRIVATE ||
+                idValue == NOTE_STORAGE_DISK ||
+                idValue == NOTE_STORAGE_MOVE) return getAutoIncrementNotificationId();
+        else return idValue;
+    }
+
     private static int pushAndGetNotificationId(String modulePackageName,
                                                 int moduleUserId,
                                                 boolean enabled,
                                                 boolean systemModule) {
         var idKey = getNotificationIdKey(modulePackageName, moduleUserId, enabled, systemModule);
-        var idValue = idKey.hashCode();
+        var idValue = getAutoIncrementNotificationId();
         notificationIds.putIfAbsent(idKey, idValue);
         return idValue;
     }

--- a/daemon/src/main/java/org/lsposed/lspd/service/LSPManagerService.java
+++ b/daemon/src/main/java/org/lsposed/lspd/service/LSPManagerService.java
@@ -92,7 +92,6 @@ public class LSPManagerService extends ILSPManagerService.Stub {
     public static final String CHANNEL_NAME = "LSPosed Manager";
     public static final int CHANNEL_IMP = NotificationManager.IMPORTANCE_HIGH;
 
-    private static final String NOTIFICATION_TAG = "114514";
     private static final HashMap<String, Integer> notificationIds = new HashMap<>();
 
     private static final HandlerThread worker = new HandlerThread("manager worker");
@@ -273,7 +272,7 @@ public class LSPManagerService extends ILSPManagerService.Stub {
                     new NotificationChannel(CHANNEL_ID, CHANNEL_NAME, CHANNEL_IMP);
             im.createNotificationChannels("android",
                     new android.content.pm.ParceledListSlice<>(Collections.singletonList(channel)));
-            im.enqueueNotificationWithTag("android", "android", NOTIFICATION_TAG,
+            im.enqueueNotificationWithTag("android", "android", modulePackageName,
                     pushAndGetNotificationId(modulePackageName, moduleUserId, enabled, systemModule),
                     notification, 0);
         } catch (Throwable e) {
@@ -290,7 +289,7 @@ public class LSPManagerService extends ILSPManagerService.Stub {
             var notificationId = notificationIds.get(idKey);
             if (notificationId == null) return;
             var im = INotificationManager.Stub.asInterface(android.os.ServiceManager.getService("notification"));
-            im.cancelNotificationWithTag("android", "android", NOTIFICATION_TAG, notificationId, 0);
+            im.cancelNotificationWithTag("android", "android", modulePackageName, notificationId, 0);
             notificationIds.remove(idKey);
         } catch (Throwable e) {
             Log.e(TAG, "cancel notification", e);

--- a/daemon/src/main/java/org/lsposed/lspd/service/LSPosedService.java
+++ b/daemon/src/main/java/org/lsposed/lspd/service/LSPosedService.java
@@ -179,7 +179,8 @@ public class LSPosedService extends ILSPosedService.Stub {
             if (!(Intent.ACTION_UID_REMOVED.equals(action) || Intent.ACTION_PACKAGE_FULLY_REMOVED.equals(action) || allUsers))
                 LSPManagerService.showNotification(packageName, userId, enabled, systemModule);
             // Canceled the notification when Xposed Module removed
-            if (Intent.ACTION_PACKAGE_FULLY_REMOVED.equals(action)) LSPManagerService.cancelNotification();
+            if (Intent.ACTION_PACKAGE_FULLY_REMOVED.equals(action))
+                LSPManagerService.cancelNotification(packageName, userId, enabled, systemModule);
         }
     }
 

--- a/daemon/src/main/java/org/lsposed/lspd/service/LSPosedService.java
+++ b/daemon/src/main/java/org/lsposed/lspd/service/LSPosedService.java
@@ -178,6 +178,8 @@ public class LSPosedService extends ILSPosedService.Stub {
             boolean enabled = Arrays.asList(enabledModules).contains(packageName);
             if (!(Intent.ACTION_UID_REMOVED.equals(action) || Intent.ACTION_PACKAGE_FULLY_REMOVED.equals(action) || allUsers))
                 LSPManagerService.showNotification(packageName, userId, enabled, systemModule);
+            // Canceled the notification when Xposed Module removed
+            if (Intent.ACTION_PACKAGE_FULLY_REMOVED.equals(action)) LSPManagerService.cancelNotification();
         }
     }
 

--- a/daemon/src/main/java/org/lsposed/lspd/service/LSPosedService.java
+++ b/daemon/src/main/java/org/lsposed/lspd/service/LSPosedService.java
@@ -179,8 +179,7 @@ public class LSPosedService extends ILSPosedService.Stub {
             if (!(Intent.ACTION_UID_REMOVED.equals(action) || Intent.ACTION_PACKAGE_FULLY_REMOVED.equals(action) || allUsers))
                 LSPManagerService.showNotification(packageName, userId, enabled, systemModule);
             // Canceled the notification when Xposed Module removed
-            if (Intent.ACTION_PACKAGE_FULLY_REMOVED.equals(action))
-                LSPManagerService.cancelNotification(packageName, userId, enabled, systemModule);
+            if (Intent.ACTION_PACKAGE_FULLY_REMOVED.equals(action)) LSPManagerService.cancelNotification(packageName, userId);
         }
     }
 

--- a/hiddenapi/stubs/src/main/java/android/app/INotificationManager.java
+++ b/hiddenapi/stubs/src/main/java/android/app/INotificationManager.java
@@ -9,6 +9,7 @@ import android.os.RemoteException;
 public interface INotificationManager extends IInterface {
     void enqueueNotificationWithTag(String pkg, String opPkg, String tag, int id,
                                     Notification notification, int userId) throws RemoteException;
+    void cancelNotificationWithTag(String pkg, String opPkg, String tag, int id, int userId) throws RemoteException;
     void createNotificationChannels(String pkg, ParceledListSlice<NotificationChannel> channelsList) throws RemoteException;
 
     abstract class Stub extends Binder implements INotificationManager {


### PR DESCRIPTION
When the Xposed Module was installed, LSPosed will send a notification that the module has not yet been activated. At this time, if the module is uninstalled and the user without clearing the notification by hand, the notification will not be auto cleared.
Also, I found that every time a new module is installed, the previous notification that the module is not activated will be replaced.
This change will probably resolve those issue.