### PR TITLE
Changed: The notification prompt will not contain the current username when the primary user installs the Xposed Module

### DIFF
--- a/daemon/src/main/java/org/lsposed/lspd/service/LSPManagerService.java
+++ b/daemon/src/main/java/org/lsposed/lspd/service/LSPManagerService.java
@@ -223,11 +223,8 @@ public class LSPManagerService extends ILSPManagerService.Stub {
         }
     }
 
-    private static String getNotificationIdKey(String modulePackageName,
-                                               int moduleUserId,
-                                               boolean enabled,
-                                               boolean systemModule) {
-        return modulePackageName + ":" + moduleUserId + ":" + enabled + ":" + systemModule;
+    private static String getNotificationIdKey(String modulePackageName, int moduleUserId) {
+        return modulePackageName + ":" + moduleUserId;
     }
 
     private static int getAutoIncrementNotificationId() {
@@ -251,11 +248,8 @@ public class LSPManagerService extends ILSPManagerService.Stub {
         else return idValue;
     }
 
-    private static int pushAndGetNotificationId(String modulePackageName,
-                                                int moduleUserId,
-                                                boolean enabled,
-                                                boolean systemModule) {
-        var idKey = getNotificationIdKey(modulePackageName, moduleUserId, enabled, systemModule);
+    private static int pushAndGetNotificationId(String modulePackageName, int moduleUserId) {
+        var idKey = getNotificationIdKey(modulePackageName, moduleUserId);
         var idValue = getAutoIncrementNotificationId();
         notificationIds.putIfAbsent(idKey, idValue);
         return idValue;
@@ -295,19 +289,16 @@ public class LSPManagerService extends ILSPManagerService.Stub {
             im.createNotificationChannels("android",
                     new android.content.pm.ParceledListSlice<>(Collections.singletonList(channel)));
             im.enqueueNotificationWithTag("android", "android", modulePackageName,
-                    pushAndGetNotificationId(modulePackageName, moduleUserId, enabled, systemModule),
+                    pushAndGetNotificationId(modulePackageName, moduleUserId),
                     notification, 0);
         } catch (Throwable e) {
             Log.e(TAG, "post notification", e);
         }
     }
 
-    public static void cancelNotification(String modulePackageName,
-                                          int moduleUserId,
-                                          boolean enabled,
-                                          boolean systemModule) {
+    public static void cancelNotification(String modulePackageName, int moduleUserId) {
         try {
-            var idKey = getNotificationIdKey(modulePackageName, moduleUserId, enabled, systemModule);
+            var idKey = getNotificationIdKey(modulePackageName, moduleUserId);
             var notificationId = notificationIds.get(idKey);
             if (notificationId == null) return;
             var im = INotificationManager.Stub.asInterface(android.os.ServiceManager.getService("notification"));

--- a/daemon/src/main/java/org/lsposed/lspd/service/LSPManagerService.java
+++ b/daemon/src/main/java/org/lsposed/lspd/service/LSPManagerService.java
@@ -256,8 +256,9 @@ public class LSPManagerService extends ILSPManagerService.Stub {
         var idValue = notificationIds.get(idKey);
         // If there is a new notification, put a new notification id into map
         if (idValue == null) {
-            idValue = getAutoIncrementNotificationId();
-            notificationIds.putIfAbsent(idKey, idValue);
+            int newIdValue = getAutoIncrementNotificationId();
+            idValue = newIdValue;
+            notificationIds.computeIfAbsent(idKey, key -> newIdValue);
         }
         return idValue;
     }

--- a/daemon/src/main/java/org/lsposed/lspd/service/LSPManagerService.java
+++ b/daemon/src/main/java/org/lsposed/lspd/service/LSPManagerService.java
@@ -234,6 +234,7 @@ public class LSPManagerService extends ILSPManagerService.Stub {
         // previousNotificationId start with 2001
         var idValue = previousNotificationId++;
         // Templates that may conflict with system ids after 2000
+        // Copied from https://android.googlesource.com/platform/frameworks/base/+/master/proto/src/system_messages.proto
         var NOTE_NETWORK_AVAILABLE = 17303299;
         var NOTE_REMOTE_BUGREPORT = 678432343;
         var NOTE_STORAGE_PUBLIC = 0x53505542;

--- a/daemon/src/main/java/org/lsposed/lspd/service/LSPManagerService.java
+++ b/daemon/src/main/java/org/lsposed/lspd/service/LSPManagerService.java
@@ -272,7 +272,9 @@ public class LSPManagerService extends ILSPManagerService.Stub {
             String content = context.getString(enabled ? systemModule ?
                     R.string.xposed_module_updated_notification_content_system :
                     R.string.xposed_module_updated_notification_content :
-                    R.string.module_is_not_activated_yet_detailed, modulePackageName, userName);
+                    (moduleUserId == 0 ?
+                            R.string.module_is_not_activated_yet_main_user_detailed :
+                            R.string.module_is_not_activated_yet_multi_user_detailed), modulePackageName, userName);
 
             var style = new Notification.BigTextStyle();
             style.bigText(content);

--- a/daemon/src/main/java/org/lsposed/lspd/service/LSPManagerService.java
+++ b/daemon/src/main/java/org/lsposed/lspd/service/LSPManagerService.java
@@ -253,14 +253,8 @@ public class LSPManagerService extends ILSPManagerService.Stub {
 
     private static int pushAndGetNotificationId(String modulePackageName, int moduleUserId) {
         var idKey = getNotificationIdKey(modulePackageName, moduleUserId);
-        var idValue = notificationIds.get(idKey);
         // If there is a new notification, put a new notification id into map
-        if (idValue == null) {
-            int newIdValue = getAutoIncrementNotificationId();
-            idValue = newIdValue;
-            notificationIds.computeIfAbsent(idKey, key -> newIdValue);
-        }
-        return idValue;
+        return notificationIds.computeIfAbsent(idKey, key -> getAutoIncrementNotificationId());
     }
 
     private static int removeAndGetNotificationId(String modulePackageName, int moduleUserId) {

--- a/daemon/src/main/java/org/lsposed/lspd/service/LSPManagerService.java
+++ b/daemon/src/main/java/org/lsposed/lspd/service/LSPManagerService.java
@@ -244,8 +244,11 @@ public class LSPManagerService extends ILSPManagerService.Stub {
                 idValue == NOTE_STORAGE_PUBLIC ||
                 idValue == NOTE_STORAGE_PRIVATE ||
                 idValue == NOTE_STORAGE_DISK ||
-                idValue == NOTE_STORAGE_MOVE) return getAutoIncrementNotificationId();
-        else return idValue;
+                idValue == NOTE_STORAGE_MOVE) {
+            return getAutoIncrementNotificationId();
+        } else {
+            return idValue;
+        }
     }
 
     private static int pushAndGetNotificationId(String modulePackageName, int moduleUserId) {

--- a/daemon/src/main/java/org/lsposed/lspd/service/LSPManagerService.java
+++ b/daemon/src/main/java/org/lsposed/lspd/service/LSPManagerService.java
@@ -259,6 +259,15 @@ public class LSPManagerService extends ILSPManagerService.Stub {
         }
     }
 
+    public static void cancelNotification() {
+        try {
+            var im = INotificationManager.Stub.asInterface(android.os.ServiceManager.getService("notification"));
+            im.cancelNotificationWithTag("android", "android", "114514", NOTIFICATION_ID, 0);
+        } catch (Throwable e) {
+            Log.e(TAG, "cancel notification", e);
+        }
+    }
+
     @SuppressLint("WrongConstant")
     public static void broadcastIntent(Intent inIntent) {
         var intent = new Intent("org.lsposed.manager.NOTIFICATION");

--- a/daemon/src/main/java/org/lsposed/lspd/service/LSPManagerService.java
+++ b/daemon/src/main/java/org/lsposed/lspd/service/LSPManagerService.java
@@ -236,7 +236,7 @@ public class LSPManagerService extends ILSPManagerService.Stub {
                                                 boolean systemModule) {
         var idKey = getNotificationIdKey(modulePackageName, moduleUserId, enabled, systemModule);
         var idValue = idKey.hashCode();
-        notificationIds.put(idKey, idValue);
+        notificationIds.putIfAbsent(idKey, idValue);
         return idValue;
     }
 

--- a/daemon/src/main/java/org/lsposed/lspd/service/LSPManagerService.java
+++ b/daemon/src/main/java/org/lsposed/lspd/service/LSPManagerService.java
@@ -93,6 +93,7 @@ public class LSPManagerService extends ILSPManagerService.Stub {
     public static final int CHANNEL_IMP = NotificationManager.IMPORTANCE_HIGH;
 
     private static final HashMap<String, Integer> notificationIds = new HashMap<>();
+    private static int previousNotificationId = 2000;
 
     private static final HandlerThread worker = new HandlerThread("manager worker");
     private static final Handler workerHandler;
@@ -229,12 +230,32 @@ public class LSPManagerService extends ILSPManagerService.Stub {
         return modulePackageName + ":" + moduleUserId + ":" + enabled + ":" + systemModule;
     }
 
+    private static int getAutoIncrementNotificationId() {
+        // previousNotificationId start with 2001
+        var idValue = previousNotificationId++;
+        // Templates that may conflict with system ids after 2000
+        var NOTE_NETWORK_AVAILABLE = 17303299;
+        var NOTE_REMOTE_BUGREPORT = 678432343;
+        var NOTE_STORAGE_PUBLIC = 0x53505542;
+        var NOTE_STORAGE_PRIVATE = 0x53505256;
+        var NOTE_STORAGE_DISK = 0x5344534b;
+        var NOTE_STORAGE_MOVE = 0x534d4f56;
+        // If auto created id is conflict, recreate it
+        if (idValue == NOTE_NETWORK_AVAILABLE ||
+                idValue == NOTE_REMOTE_BUGREPORT ||
+                idValue == NOTE_STORAGE_PUBLIC ||
+                idValue == NOTE_STORAGE_PRIVATE ||
+                idValue == NOTE_STORAGE_DISK ||
+                idValue == NOTE_STORAGE_MOVE) return getAutoIncrementNotificationId();
+        else return idValue;
+    }
+
     private static int pushAndGetNotificationId(String modulePackageName,
                                                 int moduleUserId,
                                                 boolean enabled,
                                                 boolean systemModule) {
         var idKey = getNotificationIdKey(modulePackageName, moduleUserId, enabled, systemModule);
-        var idValue = idKey.hashCode();
+        var idValue = getAutoIncrementNotificationId();
         notificationIds.putIfAbsent(idKey, idValue);
         return idValue;
     }

--- a/daemon/src/main/java/org/lsposed/lspd/service/LSPManagerService.java
+++ b/daemon/src/main/java/org/lsposed/lspd/service/LSPManagerService.java
@@ -92,7 +92,6 @@ public class LSPManagerService extends ILSPManagerService.Stub {
     public static final String CHANNEL_NAME = "LSPosed Manager";
     public static final int CHANNEL_IMP = NotificationManager.IMPORTANCE_HIGH;
 
-    private static final String NOTIFICATION_TAG = "114514";
     private static final HashMap<String, Integer> notificationIds = new HashMap<>();
 
     private static final HandlerThread worker = new HandlerThread("manager worker");
@@ -273,7 +272,7 @@ public class LSPManagerService extends ILSPManagerService.Stub {
                     new NotificationChannel(CHANNEL_ID, CHANNEL_NAME, CHANNEL_IMP);
             im.createNotificationChannels("android",
                     new android.content.pm.ParceledListSlice<>(Collections.singletonList(channel)));
-            im.enqueueNotificationWithTag("android", "android", NOTIFICATION_TAG,
+            im.enqueueNotificationWithTag("android", "android", modulePackageName,
                     pushAndGetNotificationId(modulePackageName, moduleUserId, enabled, systemModule),
                     notification, 0);
         } catch (Throwable e) {
@@ -290,7 +289,7 @@ public class LSPManagerService extends ILSPManagerService.Stub {
             var notificationId = notificationIds.get(idKey);
             if (notificationId == null) return;
             var im = INotificationManager.Stub.asInterface(android.os.ServiceManager.getService("notification"));
-            im.cancelNotificationWithTag("android", "android", NOTIFICATION_TAG, notificationId, 0);
+            im.cancelNotificationWithTag("android", "android", modulePackageName, notificationId, 0);
             notificationIds.remove(idKey);
         } catch (Throwable e) {
             Log.e(TAG, "cancel notification", e);

--- a/daemon/src/main/java/org/lsposed/lspd/service/LSPosedService.java
+++ b/daemon/src/main/java/org/lsposed/lspd/service/LSPosedService.java
@@ -179,7 +179,8 @@ public class LSPosedService extends ILSPosedService.Stub {
             if (!(Intent.ACTION_UID_REMOVED.equals(action) || Intent.ACTION_PACKAGE_FULLY_REMOVED.equals(action) || allUsers))
                 LSPManagerService.showNotification(packageName, userId, enabled, systemModule);
             // Canceled the notification when Xposed Module removed
-            if (Intent.ACTION_PACKAGE_FULLY_REMOVED.equals(action)) LSPManagerService.cancelNotification();
+            if (Intent.ACTION_PACKAGE_FULLY_REMOVED.equals(action))
+                LSPManagerService.cancelNotification(packageName, userId, enabled, systemModule);
         }
     }
 

--- a/daemon/src/main/java/org/lsposed/lspd/service/LSPosedService.java
+++ b/daemon/src/main/java/org/lsposed/lspd/service/LSPosedService.java
@@ -178,6 +178,8 @@ public class LSPosedService extends ILSPosedService.Stub {
             boolean enabled = Arrays.asList(enabledModules).contains(packageName);
             if (!(Intent.ACTION_UID_REMOVED.equals(action) || Intent.ACTION_PACKAGE_FULLY_REMOVED.equals(action) || allUsers))
                 LSPManagerService.showNotification(packageName, userId, enabled, systemModule);
+            // Canceled the notification when Xposed Module removed
+            if (Intent.ACTION_PACKAGE_FULLY_REMOVED.equals(action)) LSPManagerService.cancelNotification();
         }
     }
 

--- a/daemon/src/main/java/org/lsposed/lspd/service/LSPosedService.java
+++ b/daemon/src/main/java/org/lsposed/lspd/service/LSPosedService.java
@@ -176,7 +176,7 @@ public class LSPosedService extends ILSPosedService.Stub {
             boolean systemModule = scope != null &&
                     scope.parallelStream().anyMatch(app -> app.packageName.equals("android"));
             boolean enabled = Arrays.asList(enabledModules).contains(packageName);
-            if (!(Intent.ACTION_UID_REMOVED.equals(action) || Intent.ACTION_PACKAGE_FULLY_REMOVED.equals(action) || allUsers))
+            if (!Intent.ACTION_UID_REMOVED.equals(action) && !Intent.ACTION_PACKAGE_FULLY_REMOVED.equals(action) && !allUsers)
                 LSPManagerService.showNotification(packageName, userId, enabled, systemModule);
             // Canceled the notification when Xposed Module removed
             if (Intent.ACTION_PACKAGE_FULLY_REMOVED.equals(action)) LSPManagerService.cancelNotification(packageName, userId);

--- a/daemon/src/main/java/org/lsposed/lspd/service/LSPosedService.java
+++ b/daemon/src/main/java/org/lsposed/lspd/service/LSPosedService.java
@@ -179,8 +179,7 @@ public class LSPosedService extends ILSPosedService.Stub {
             if (!(Intent.ACTION_UID_REMOVED.equals(action) || Intent.ACTION_PACKAGE_FULLY_REMOVED.equals(action) || allUsers))
                 LSPManagerService.showNotification(packageName, userId, enabled, systemModule);
             // Canceled the notification when Xposed Module removed
-            if (Intent.ACTION_PACKAGE_FULLY_REMOVED.equals(action))
-                LSPManagerService.cancelNotification(packageName, userId, enabled, systemModule);
+            if (Intent.ACTION_PACKAGE_FULLY_REMOVED.equals(action)) LSPManagerService.cancelNotification(packageName, userId);
         }
     }
 

--- a/daemon/src/main/java/org/lsposed/lspd/service/LSPosedService.java
+++ b/daemon/src/main/java/org/lsposed/lspd/service/LSPosedService.java
@@ -109,8 +109,14 @@ public class LSPosedService extends ILSPosedService.Stub {
                         isXposedModule = true;
                         broadcastAndShowNotification(moduleName, userId, intent, true);
                     }
+                // Anyway, canceled the notification
+                if (moduleName != null) LSPManagerService.cancelNotification(moduleName, userId);
                 break;
             }
+            case Intent.ACTION_PACKAGE_REMOVED:
+                // Anyway, canceled the notification
+                if (moduleName != null) LSPManagerService.cancelNotification(moduleName, userId);
+                break;
             case Intent.ACTION_PACKAGE_ADDED:
             case Intent.ACTION_PACKAGE_CHANGED: {
                 // make sure that the change is for the complete package, not only a
@@ -176,11 +182,8 @@ public class LSPosedService extends ILSPosedService.Stub {
             boolean systemModule = scope != null &&
                     scope.parallelStream().anyMatch(app -> app.packageName.equals("android"));
             boolean enabled = Arrays.asList(enabledModules).contains(packageName);
-            // Exclude Xposed Module uninstall event
-            if (!Intent.ACTION_UID_REMOVED.equals(action) && !Intent.ACTION_PACKAGE_FULLY_REMOVED.equals(action) && !allUsers)
+            if (!(Intent.ACTION_UID_REMOVED.equals(action) || Intent.ACTION_PACKAGE_FULLY_REMOVED.equals(action) || allUsers))
                 LSPManagerService.showNotification(packageName, userId, enabled, systemModule);
-            // Canceled the notification when Xposed Module removed
-            if (Intent.ACTION_PACKAGE_FULLY_REMOVED.equals(action)) LSPManagerService.cancelNotification(packageName, userId);
         }
     }
 

--- a/daemon/src/main/java/org/lsposed/lspd/service/LSPosedService.java
+++ b/daemon/src/main/java/org/lsposed/lspd/service/LSPosedService.java
@@ -176,6 +176,7 @@ public class LSPosedService extends ILSPosedService.Stub {
             boolean systemModule = scope != null &&
                     scope.parallelStream().anyMatch(app -> app.packageName.equals("android"));
             boolean enabled = Arrays.asList(enabledModules).contains(packageName);
+            // Exclude Xposed Module uninstall event
             if (!Intent.ACTION_UID_REMOVED.equals(action) && !Intent.ACTION_PACKAGE_FULLY_REMOVED.equals(action) && !allUsers)
                 LSPManagerService.showNotification(packageName, userId, enabled, systemModule);
             // Canceled the notification when Xposed Module removed

--- a/daemon/src/main/res/values-af/strings.xml
+++ b/daemon/src/main/res/values-af/strings.xml
@@ -2,7 +2,8 @@
 <resources>
     <!-- Notification -->
     <string name="module_is_not_activated_yet">Xposed module is not activated yet</string>
-    <string name="module_is_not_activated_yet_detailed">%s is geïnstalleer, maar is nog nie geaktiveer nie</string>
+    <string name="module_is_not_activated_yet_main_user_detailed">%s is geïnstalleer, maar is nog nie geaktiveer nie</string>
+    <string name="module_is_not_activated_yet_multi_user_detailed">%s is geïnstalleer, maar is nog nie geaktiveer nie</string>
     <string name="xposed_module_updated_notification_title">%d module enabled</string>
     <string name="xposed_module_updated_notification_content">%s is opgedateer, forseer asseblief stop en herbegin programme binne die omvang daarvan</string>
     <string name="xposed_module_updated_notification_title_system">Xposed-module is opgedateer, stelselherlaai vereis</string>

--- a/daemon/src/main/res/values-ar/strings.xml
+++ b/daemon/src/main/res/values-ar/strings.xml
@@ -2,7 +2,8 @@
 <resources>
     <!-- Notification -->
     <string name="module_is_not_activated_yet">وحدة Xposed لم يتم تفعيلها بعد</string>
-    <string name="module_is_not_activated_yet_detailed">%s تم تثبيته، ولكن لم يتم تفعيله بعد</string>
+    <string name="module_is_not_activated_yet_main_user_detailed">%s تم تثبيته، ولكن لم يتم تفعيله بعد</string>
+    <string name="module_is_not_activated_yet_multi_user_detailed">%s تم تثبيته، ولكن لم يتم تفعيله بعد</string>
     <string name="xposed_module_updated_notification_title">وحدة Xposed تم تحديثها</string>
     <string name="xposed_module_updated_notification_content">%s تم تحديثه، يرجى فرض إيقاف وإعادة تشغيل التطبيقات في نطاقه</string>
     <string name="xposed_module_updated_notification_title_system">تم تحديث وحدة Xposed، مطلوب إعادة تشغيل النظام</string>

--- a/daemon/src/main/res/values-bn/strings.xml
+++ b/daemon/src/main/res/values-bn/strings.xml
@@ -2,7 +2,8 @@
 <resources>
     <!-- Notification -->
     <string name="module_is_not_activated_yet">Xposed মডিউল এখনও সক্রিয় করা হয় নি</string>
-    <string name="module_is_not_activated_yet_detailed">%s ইনস্টল করা হয়েছে, কিন্তু এখনও সক্রিয় করা হয়নি</string>
+    <string name="module_is_not_activated_yet_main_user_detailed">%s ইনস্টল করা হয়েছে, কিন্তু এখনও সক্রিয় করা হয়নি</string>
+    <string name="module_is_not_activated_yet_multi_user_detailed">%s ইনস্টল করা হয়েছে, কিন্তু এখনও সক্রিয় করা হয়নি</string>
     <string name="xposed_module_updated_notification_title">এক্সপোজড মডিউল আপডেট করা হয়েছে</string>
     <string name="xposed_module_updated_notification_content">%s আপডেট করা হয়েছে, অনুগ্রহ করে এর সুযোগে অ্যাপগুলিকে জোর করে থামান এবং পুনরায় চালু করুন</string>
     <string name="xposed_module_updated_notification_title_system">Xposed মডিউল আপডেট করা হয়েছে, সিস্টেম রিবুট প্রয়োজন</string>

--- a/daemon/src/main/res/values-ca/strings.xml
+++ b/daemon/src/main/res/values-ca/strings.xml
@@ -2,7 +2,8 @@
 <resources>
     <!-- Notification -->
     <string name="module_is_not_activated_yet">El mòdul Xposed encara no està activat</string>
-    <string name="module_is_not_activated_yet_detailed">%s s\'ha instal·lat, però encara no està activat</string>
+    <string name="module_is_not_activated_yet_main_user_detailed">%s s\'ha instal·lat, però encara no està activat</string>
+    <string name="module_is_not_activated_yet_multi_user_detailed">%s s\'ha instal·lat, però encara no està activat</string>
     <string name="xposed_module_updated_notification_title">Mòdul Xposed actualitzat</string>
     <string name="xposed_module_updated_notification_content">%s s\'ha actualitzat, si us plau, força l\'aturada i reinici de les aplicacions del seu abast</string>
     <string name="xposed_module_updated_notification_title_system">Mòdul Xposed actualitzat, cal reiniciar el sistema</string>

--- a/daemon/src/main/res/values-cs/strings.xml
+++ b/daemon/src/main/res/values-cs/strings.xml
@@ -2,7 +2,8 @@
 <resources>
     <!-- Notification -->
     <string name="module_is_not_activated_yet">Xposed modul ještě není aktivován</string>
-    <string name="module_is_not_activated_yet_detailed">%s byl nainstalován, ale ještě není aktivován</string>
+    <string name="module_is_not_activated_yet_main_user_detailed">%s byl nainstalován, ale ještě není aktivován</string>
+    <string name="module_is_not_activated_yet_multi_user_detailed">%s byl nainstalován, ale ještě není aktivován</string>
     <string name="xposed_module_updated_notification_title">Xposed modul byl aktualizován</string>
     <string name="xposed_module_updated_notification_content">%s byl aktualizován, prosím, násilně zastavte aplikace a restartujte je</string>
     <string name="xposed_module_updated_notification_title_system">Xposed modul aktualizován, je vyžadován restart systému</string>

--- a/daemon/src/main/res/values-da/strings.xml
+++ b/daemon/src/main/res/values-da/strings.xml
@@ -2,7 +2,8 @@
 <resources>
     <!-- Notification -->
     <string name="module_is_not_activated_yet">Xposed modul er endnu ikke aktiveret</string>
-    <string name="module_is_not_activated_yet_detailed">%s er blevet installeret, men er ikke aktiveret endnu</string>
+    <string name="module_is_not_activated_yet_main_user_detailed">%s er blevet installeret, men er ikke aktiveret endnu</string>
+    <string name="module_is_not_activated_yet_multi_user_detailed">%s er blevet installeret, men er ikke aktiveret endnu</string>
     <string name="xposed_module_updated_notification_title">Xposed modul opdateret</string>
     <string name="xposed_module_updated_notification_content">%s er blevet opdateret, gennemtving stop og genstart apps i dets anvendelsesområde</string>
     <string name="xposed_module_updated_notification_title_system">Xposed modul opdateret, system genstart kræves</string>

--- a/daemon/src/main/res/values-de/strings.xml
+++ b/daemon/src/main/res/values-de/strings.xml
@@ -2,7 +2,8 @@
 <resources>
     <!-- Notification -->
     <string name="module_is_not_activated_yet">Das LSPosed-Modul wurde noch nicht aktiviert</string>
-    <string name="module_is_not_activated_yet_detailed">%s wurde installiert, aber noch nicht aktiviert</string>
+    <string name="module_is_not_activated_yet_main_user_detailed">%s wurde installiert, aber noch nicht aktiviert</string>
+    <string name="module_is_not_activated_yet_multi_user_detailed">%s wurde installiert, aber noch nicht aktiviert</string>
     <string name="xposed_module_updated_notification_title">Xposed-Modul aktualisiert</string>
     <string name="xposed_module_updated_notification_content">%s wurde aktualisiert, bitte Stopp erzwingen und die Apps in deren Scope neu starten</string>
     <string name="xposed_module_updated_notification_title_system">Xposed-Modul aktualisiert, Systemneustart erforderlich</string>

--- a/daemon/src/main/res/values-el/strings.xml
+++ b/daemon/src/main/res/values-el/strings.xml
@@ -2,7 +2,8 @@
 <resources>
     <!-- Notification -->
     <string name="module_is_not_activated_yet">Το Xposed πρόσθετο δεν έχει ενεργοποιηθεί ακόμα</string>
-    <string name="module_is_not_activated_yet_detailed">%s έχει εγκατασταθεί, αλλά δεν έχει ενεργοποιηθεί ακόμα</string>
+    <string name="module_is_not_activated_yet_main_user_detailed">%s έχει εγκατασταθεί, αλλά δεν έχει ενεργοποιηθεί ακόμα</string>
+    <string name="module_is_not_activated_yet_multi_user_detailed">%s έχει εγκατασταθεί, αλλά δεν έχει ενεργοποιηθεί ακόμα</string>
     <string name="xposed_module_updated_notification_title">Το πρόσθετο Xposed ενημερώθηκε</string>
     <string name="xposed_module_updated_notification_content">%s ενημερώθηκε, παρακαλώ κλείστε εξαναγκαστικά και επανεκκινήστε τις εφαρμογές στο πεδίο εφαρμογής της</string>
     <string name="xposed_module_updated_notification_title_system">Το πρόσθετο Xposed ενημερώθηκε, απαιτείται επανεκκίνηση συστήματος</string>

--- a/daemon/src/main/res/values-es/strings.xml
+++ b/daemon/src/main/res/values-es/strings.xml
@@ -2,7 +2,8 @@
 <resources>
     <!-- Notification -->
     <string name="module_is_not_activated_yet">El módulo Xposed no se encuentra activo</string>
-    <string name="module_is_not_activated_yet_detailed">%s ha sido instalado, pero no está activado aún</string>
+    <string name="module_is_not_activated_yet_main_user_detailed">%s ha sido instalado, pero no está activado aún</string>
+    <string name="module_is_not_activated_yet_multi_user_detailed">%s ha sido instalado, pero no está activado aún</string>
     <string name="xposed_module_updated_notification_title">Módulo Xposed actualizado</string>
     <string name="xposed_module_updated_notification_content">%s ha sido actualizado, por favor fuerza el cierre y reinicia las apps que le afectan</string>
     <string name="xposed_module_updated_notification_title_system">Módulo de Xposed actualizado, es necesario reiniciar el sistema</string>

--- a/daemon/src/main/res/values-fa/strings.xml
+++ b/daemon/src/main/res/values-fa/strings.xml
@@ -2,7 +2,8 @@
 <resources>
     <!-- Notification -->
     <string name="module_is_not_activated_yet">ماژول Xposed در حال حاضر فعال نشده</string>
-    <string name="module_is_not_activated_yet_detailed">%s نصب شده ، اما فعال نشده</string>
+    <string name="module_is_not_activated_yet_main_user_detailed">%s نصب شده ، اما فعال نشده</string>
+    <string name="module_is_not_activated_yet_multi_user_detailed">%s نصب شده ، اما فعال نشده</string>
     <string name="xposed_module_updated_notification_title">ماژول Xposed بروزرسانی شد</string>
     <string name="xposed_module_updated_notification_content">%s بروز شد، لطفا توقف اجباری و ریستارت کنید برنامه های این محدوده را</string>
     <string name="xposed_module_updated_notification_title_system">ماژول Xposed بروز شد، راه‌اندازی سیستم نیاز است</string>

--- a/daemon/src/main/res/values-fi/strings.xml
+++ b/daemon/src/main/res/values-fi/strings.xml
@@ -2,7 +2,8 @@
 <resources>
     <!-- Notification -->
     <string name="module_is_not_activated_yet">Xposed moduuli ei ole vielä aktivoitu</string>
-    <string name="module_is_not_activated_yet_detailed">%s on asennettu, mutta ei ole vielä aktivoitu</string>
+    <string name="module_is_not_activated_yet_main_user_detailed">%s on asennettu, mutta ei ole vielä aktivoitu</string>
+    <string name="module_is_not_activated_yet_multi_user_detailed">%s on asennettu, mutta ei ole vielä aktivoitu</string>
     <string name="xposed_module_updated_notification_title">Xposed moduuli päivitetty</string>
     <string name="xposed_module_updated_notification_content">%s on päivitetty, paina pysäytä ja käynnistä sovellukset uudelleen sen laajuudessa</string>
     <string name="xposed_module_updated_notification_title_system">Xposed moduuli päivitetty, järjestelmän uudelleenkäynnistys vaaditaan</string>

--- a/daemon/src/main/res/values-fr/strings.xml
+++ b/daemon/src/main/res/values-fr/strings.xml
@@ -2,7 +2,8 @@
 <resources>
     <!-- Notification -->
     <string name="module_is_not_activated_yet">Le module LSPosed n\’est pas encore actif</string>
-    <string name="module_is_not_activated_yet_detailed">%s a été installé, mais n\'est pas encore actif</string>
+    <string name="module_is_not_activated_yet_main_user_detailed">%s a été installé, mais n\'est pas encore actif</string>
+    <string name="module_is_not_activated_yet_multi_user_detailed">%s a été installé, mais n\'est pas encore actif</string>
     <string name="xposed_module_updated_notification_title">Module Xposed mis à jour</string>
     <string name="xposed_module_updated_notification_content">%s a été mis à jour, merci de forcer l\’arrêt ou de redémarrer les applis dans leurs champs d\’application</string>
     <string name="xposed_module_updated_notification_title_system">Module Xposed mis à jour, redémarrage du système requis</string>

--- a/daemon/src/main/res/values-hi/strings.xml
+++ b/daemon/src/main/res/values-hi/strings.xml
@@ -2,7 +2,8 @@
 <resources>
     <!-- Notification -->
     <string name="module_is_not_activated_yet">एक्सपोज़ड मॉड्यूल अभी तक सक्रिय नहीं है</string>
-    <string name="module_is_not_activated_yet_detailed">%s स्थापित किया गया है, लेकिन अभी तक सक्रिय नहीं हुआ है</string>
+    <string name="module_is_not_activated_yet_main_user_detailed">%s स्थापित किया गया है, लेकिन अभी तक सक्रिय नहीं हुआ है</string>
+    <string name="module_is_not_activated_yet_multi_user_detailed">%s स्थापित किया गया है, लेकिन अभी तक सक्रिय नहीं हुआ है</string>
     <string name="xposed_module_updated_notification_title">एक्सपोज़ड मॉड्यूल अपडेट किया गया</string>
     <string name="xposed_module_updated_notification_content">%s अपडेट कर दिया गया है, कृपया बलपूर्वक रोकें और इसके दायरे में ऐप्स को पुनरारंभ करें</string>
     <string name="xposed_module_updated_notification_title_system">एक्सपोज़ड मॉड्यूल अपडेट किया गया, सिस्टम रीबूट की आवश्यकता है</string>

--- a/daemon/src/main/res/values-hu/strings.xml
+++ b/daemon/src/main/res/values-hu/strings.xml
@@ -2,7 +2,8 @@
 <resources>
     <!-- Notification -->
     <string name="module_is_not_activated_yet">Az Xposed modul még nincs aktiválva</string>
-    <string name="module_is_not_activated_yet_detailed">%s telepítve lett, de még nincs aktiválva.</string>
+    <string name="module_is_not_activated_yet_main_user_detailed">%s telepítve lett, de még nincs aktiválva.</string>
+    <string name="module_is_not_activated_yet_multi_user_detailed">%s telepítve lett, de még nincs aktiválva.</string>
     <string name="xposed_module_updated_notification_title">Xposed modul frissítve</string>
     <string name="xposed_module_updated_notification_content">%s frissítésre került, kérjük, kényszerítse az alkalmazások leállítását és újraindítását a hatókörében.</string>
     <string name="xposed_module_updated_notification_title_system">Xposed modul frissítve, rendszer újraindítás szükséges</string>

--- a/daemon/src/main/res/values-in/strings.xml
+++ b/daemon/src/main/res/values-in/strings.xml
@@ -2,7 +2,8 @@
 <resources>
     <!-- Notification -->
     <string name="module_is_not_activated_yet">Modul Xposed belum diaktifkan</string>
-    <string name="module_is_not_activated_yet_detailed">%s telah terpasang, tetapi belum diaktifkan</string>
+    <string name="module_is_not_activated_yet_main_user_detailed">%s telah terpasang, tetapi belum diaktifkan</string>
+    <string name="module_is_not_activated_yet_multi_user_detailed">%s telah terpasang, tetapi belum diaktifkan</string>
     <string name="xposed_module_updated_notification_title">Modul xposed diperbarui</string>
     <string name="xposed_module_updated_notification_content">%s telah diperbarui, harap paksa berhenti dan mulai ulang aplikasi dalam cakupannya</string>
     <string name="xposed_module_updated_notification_title_system">Modul Xposed diperbarui, mulai ulang sistem diperlukan</string>

--- a/daemon/src/main/res/values-it/strings.xml
+++ b/daemon/src/main/res/values-it/strings.xml
@@ -2,7 +2,8 @@
 <resources>
     <!-- Notification -->
     <string name="module_is_not_activated_yet">Il modulo Xposed non è ancora attivo</string>
-    <string name="module_is_not_activated_yet_detailed">%s è stato installato, ma non è ancora attivo</string>
+    <string name="module_is_not_activated_yet_main_user_detailed">%s è stato installato, ma non è ancora attivo</string>
+    <string name="module_is_not_activated_yet_multi_user_detailed">%s è stato installato, ma non è ancora attivo</string>
     <string name="xposed_module_updated_notification_title">Modulo Xposed aggiornato</string>
     <string name="xposed_module_updated_notification_content">%s è stato aggiornato, arresta e riavvia le applicazioni per le quali è abilitato</string>
     <string name="xposed_module_updated_notification_title_system">Modulo Xposed aggiornato, è necessario il riavvio del sistema</string>

--- a/daemon/src/main/res/values-iw/strings.xml
+++ b/daemon/src/main/res/values-iw/strings.xml
@@ -2,7 +2,8 @@
 <resources>
     <!-- Notification -->
     <string name="module_is_not_activated_yet">מודול LSPosed עדיין לא הופעל</string>
-    <string name="module_is_not_activated_yet_detailed">%s הותקן אך עדיין לא הופעל</string>
+    <string name="module_is_not_activated_yet_main_user_detailed">%s הותקן אך עדיין לא הופעל</string>
+    <string name="module_is_not_activated_yet_multi_user_detailed">%s הותקן אך עדיין לא הופעל</string>
     <string name="xposed_module_updated_notification_title">מודול LSPosed עודכן</string>
     <string name="xposed_module_updated_notification_content">%s עודכן</string>
     <string name="xposed_module_updated_notification_title_system">מודול Xposed עודכן, נדרש אתחול המערכת</string>

--- a/daemon/src/main/res/values-ja/strings.xml
+++ b/daemon/src/main/res/values-ja/strings.xml
@@ -2,7 +2,8 @@
 <resources>
     <!-- Notification -->
     <string name="module_is_not_activated_yet">Xposedモジュールが有効化されていません</string>
-    <string name="module_is_not_activated_yet_detailed">%s がインストール済みですが、有効化されていません</string>
+    <string name="module_is_not_activated_yet_main_user_detailed">%s がインストール済みですが、有効化されていません</string>
+    <string name="module_is_not_activated_yet_multi_user_detailed">%1$s はユーザー %2$s にインストールされていますが、有効化されていません</string>
     <string name="xposed_module_updated_notification_title">Xposedモジュールが更新されました</string>
     <string name="xposed_module_updated_notification_content">%s が更新されました。スコープ内のアプリを強制停止してから再起動してください</string>
     <string name="xposed_module_updated_notification_title_system">Xposedモジュールを更新しました。システム再起動が必要です</string>

--- a/daemon/src/main/res/values-ko/strings.xml
+++ b/daemon/src/main/res/values-ko/strings.xml
@@ -2,7 +2,8 @@
 <resources>
     <!-- Notification -->
     <string name="module_is_not_activated_yet">LSPosed 모듈이 아직 활성화되지 않았습니다.</string>
-    <string name="module_is_not_activated_yet_detailed">%s이(가) 설치되었지만 아직 활성화되지 않았습니다.</string>
+    <string name="module_is_not_activated_yet_main_user_detailed">%s이(가) 설치되었지만 아직 활성화되지 않았습니다.</string>
+    <string name="module_is_not_activated_yet_multi_user_detailed">%s이(가) 설치되었지만 아직 활성화되지 않았습니다.</string>
     <string name="xposed_module_updated_notification_title">LSPosed 모듈 업데이트</string>
     <string name="xposed_module_updated_notification_content">%s이(가) 업데이트되었습니다.</string>
     <string name="xposed_module_updated_notification_title_system">Xposed 모듈이 업데이트되었습니다, 재부팅이 필요합니다.</string>

--- a/daemon/src/main/res/values-ku/strings.xml
+++ b/daemon/src/main/res/values-ku/strings.xml
@@ -2,7 +2,8 @@
 <resources>
     <!-- Notification -->
     <string name="module_is_not_activated_yet">Modula Xposed hîn nehatiye çalak kirin</string>
-    <string name="module_is_not_activated_yet_detailed">%s hatiye saz kirin, lê hîn nehatiye aktîfkirin</string>
+    <string name="module_is_not_activated_yet_main_user_detailed">%s hatiye saz kirin, lê hîn nehatiye aktîfkirin</string>
+    <string name="module_is_not_activated_yet_multi_user_detailed">%s hatiye saz kirin, lê hîn nehatiye aktîfkirin</string>
     <string name="xposed_module_updated_notification_title">Modula Xposed hate nûve kirin</string>
     <string name="xposed_module_updated_notification_content">%s hate nûve kirin, ji kerema xwe bi zorê sepanan rawestînin û di çarçoveya wê de ji nû ve bidin destpêkirin</string>
     <string name="xposed_module_updated_notification_title_system">Modula Xposed hate nûve kirin, pêdivî ye ku pergalê ji nû ve dest pê bike</string>

--- a/daemon/src/main/res/values-lt/strings.xml
+++ b/daemon/src/main/res/values-lt/strings.xml
@@ -2,7 +2,8 @@
 <resources>
     <!-- Notification -->
     <string name="module_is_not_activated_yet">Xposed modulis dar nėra aktyvuotas</string>
-    <string name="module_is_not_activated_yet_detailed">%s įdiegtas, bet dar neaktyvuotas</string>
+    <string name="module_is_not_activated_yet_main_user_detailed">%s įdiegtas, bet dar neaktyvuotas</string>
+    <string name="module_is_not_activated_yet_multi_user_detailed">%s įdiegtas, bet dar neaktyvuotas</string>
     <string name="xposed_module_updated_notification_title">Atnaujintas Xposed modulis</string>
     <string name="xposed_module_updated_notification_content">%s buvo atnaujintas, priverstinai sustabdykite ir iš naujo paleiskite jo taikymo srityje esančias programas</string>
     <string name="xposed_module_updated_notification_title_system">Atnaujintas \"Xposed\" modulis, reikalingas sistemos perkrovimas</string>

--- a/daemon/src/main/res/values-nl/strings.xml
+++ b/daemon/src/main/res/values-nl/strings.xml
@@ -2,7 +2,8 @@
 <resources>
     <!-- Notification -->
     <string name="module_is_not_activated_yet">LSPosed module is nog niet geactiveerd</string>
-    <string name="module_is_not_activated_yet_detailed">%1$s is geïnstalleerd, maar is nog niet geactiveerd</string>
+    <string name="module_is_not_activated_yet_main_user_detailed">%1$s is geïnstalleerd, maar is nog niet geactiveerd</string>
+    <string name="module_is_not_activated_yet_multi_user_detailed">%1$s is geïnstalleerd, maar is nog niet geactiveerd</string>
     <string name="xposed_module_updated_notification_title">LSPosed module bijgewerkt</string>
     <string name="xposed_module_updated_notification_content">%1$s is geupdate</string>
     <string name="xposed_module_updated_notification_title_system">Xposed-module bijgewerkt, systeem opnieuw opstarten vereist</string>

--- a/daemon/src/main/res/values-no/strings.xml
+++ b/daemon/src/main/res/values-no/strings.xml
@@ -2,7 +2,8 @@
 <resources>
     <!-- Notification -->
     <string name="module_is_not_activated_yet">Xposed modul er ikke aktivert enda</string>
-    <string name="module_is_not_activated_yet_detailed">%s har blitt installert, men er ikke aktivert ennå</string>
+    <string name="module_is_not_activated_yet_main_user_detailed">%s har blitt installert, men er ikke aktivert ennå</string>
+    <string name="module_is_not_activated_yet_multi_user_detailed">%s har blitt installert, men er ikke aktivert ennå</string>
     <string name="xposed_module_updated_notification_title">Xposed modul er oppdatert</string>
     <string name="xposed_module_updated_notification_content">%s har blitt oppdatert, vennligst tvang-stopp og start apper på nytt i virkeområdet</string>
     <string name="xposed_module_updated_notification_title_system">Xposed modul oppdatert, system-omstart kreves</string>

--- a/daemon/src/main/res/values-pl/strings.xml
+++ b/daemon/src/main/res/values-pl/strings.xml
@@ -2,7 +2,8 @@
 <resources>
     <!-- Notification -->
     <string name="module_is_not_activated_yet">Moduł Xposed nie jest jeszcze aktywowany</string>
-    <string name="module_is_not_activated_yet_detailed">%s został zainstalowany, ale nie jest jeszcze aktywowany</string>
+    <string name="module_is_not_activated_yet_main_user_detailed">%s został zainstalowany, ale nie jest jeszcze aktywowany</string>
+    <string name="module_is_not_activated_yet_multi_user_detailed">%s został zainstalowany, ale nie jest jeszcze aktywowany</string>
     <string name="xposed_module_updated_notification_title">Moduł Xposed zaktualizowany</string>
     <string name="xposed_module_updated_notification_content">%s został zaktualizowany, wymuś zatrzymanie i ponownie uruchom aplikacje w jego zakresie</string>
     <string name="xposed_module_updated_notification_title_system">Zaktualizowano moduł Xposed, wymagane ponowne uruchomienie systemu</string>

--- a/daemon/src/main/res/values-pt-rBR/strings.xml
+++ b/daemon/src/main/res/values-pt-rBR/strings.xml
@@ -2,7 +2,8 @@
 <resources>
     <!-- Notification -->
     <string name="module_is_not_activated_yet">O módulo ainda não está ativo</string>
-    <string name="module_is_not_activated_yet_detailed">%s foi instalado. Mas, ainda falta ativar</string>
+    <string name="module_is_not_activated_yet_main_user_detailed">%s foi instalado. Mas, ainda falta ativar</string>
+    <string name="module_is_not_activated_yet_multi_user_detailed">%s foi instalado. Mas, ainda falta ativar</string>
     <string name="xposed_module_updated_notification_title">Módulo Atualizado</string>
     <string name="xposed_module_updated_notification_content">%s foi atualizado. Force a parada do módulo e reinicie os apps que estão em seu escopo</string>
     <string name="xposed_module_updated_notification_title_system">Módulo Atualizado. É necessário reiniciar o sistema</string>

--- a/daemon/src/main/res/values-pt/strings.xml
+++ b/daemon/src/main/res/values-pt/strings.xml
@@ -2,7 +2,8 @@
 <resources>
     <!-- Notification -->
     <string name="module_is_not_activated_yet">O módulo ainda não está ativo</string>
-    <string name="module_is_not_activated_yet_detailed">%s foi instalado. Mas, ainda falta ativar</string>
+    <string name="module_is_not_activated_yet_main_user_detailed">%s foi instalado. Mas, ainda falta ativar</string>
+    <string name="module_is_not_activated_yet_multi_user_detailed">%s foi instalado. Mas, ainda falta ativar</string>
     <string name="xposed_module_updated_notification_title">Módulo Atualizado</string>
     <string name="xposed_module_updated_notification_content">%s foi atualizado. Force a parada do módulo e reinicie os apps que estão em seu escopo</string>
     <string name="xposed_module_updated_notification_title_system">Módulo Atualizado. É necessário reiniciar o sistema</string>

--- a/daemon/src/main/res/values-ro/strings.xml
+++ b/daemon/src/main/res/values-ro/strings.xml
@@ -2,7 +2,8 @@
 <resources>
     <!-- Notification -->
     <string name="module_is_not_activated_yet">Modulul Xposed nu este inca activat</string>
-    <string name="module_is_not_activated_yet_detailed">%s a fost instalat, dar inca nu este activat</string>
+    <string name="module_is_not_activated_yet_main_user_detailed">%s a fost instalat, dar inca nu este activat</string>
+    <string name="module_is_not_activated_yet_multi_user_detailed">%s a fost instalat, dar inca nu este activat</string>
     <string name="xposed_module_updated_notification_title">Modulul Xposed actualizat</string>
     <string name="xposed_module_updated_notification_content">%s a fost actualizat, vă rugăm să forțați oprirea și repornirea aplicațiilor din domeniul său de aplicare</string>
     <string name="xposed_module_updated_notification_title_system">Modulul Xposed a fost actualizat, este necesară repornirea sistemului</string>

--- a/daemon/src/main/res/values-ru/strings.xml
+++ b/daemon/src/main/res/values-ru/strings.xml
@@ -2,7 +2,8 @@
 <resources>
     <!-- Notification -->
     <string name="module_is_not_activated_yet">Модуль не включен</string>
-    <string name="module_is_not_activated_yet_detailed">Модуль %s установлен, но еще не включен</string>
+    <string name="module_is_not_activated_yet_main_user_detailed">Модуль %s установлен, но еще не включен</string>
+    <string name="module_is_not_activated_yet_multi_user_detailed">Модуль %s установлен, но еще не включен</string>
     <string name="xposed_module_updated_notification_title">Модуль обновлен</string>
     <string name="xposed_module_updated_notification_content">Модуль %s обновлен, остановите и запустите приложения выбранные для модуля</string>
     <string name="xposed_module_updated_notification_title_system">Модуль обновлен, требуется перезагрузка</string>

--- a/daemon/src/main/res/values-sv/strings.xml
+++ b/daemon/src/main/res/values-sv/strings.xml
@@ -2,7 +2,8 @@
 <resources>
     <!-- Notification -->
     <string name="module_is_not_activated_yet">Xposed modul är inte aktiverad än</string>
-    <string name="module_is_not_activated_yet_detailed">%s har installerats men är inte aktiverat ännu</string>
+    <string name="module_is_not_activated_yet_main_user_detailed">%s har installerats men är inte aktiverat ännu</string>
+    <string name="module_is_not_activated_yet_multi_user_detailed">%s har installerats men är inte aktiverat ännu</string>
     <string name="xposed_module_updated_notification_title">Xposed modul uppdaterad</string>
     <string name="xposed_module_updated_notification_content">%s har uppdaterats. Tvinga stopp och starta om appar i dess omfattning</string>
     <string name="xposed_module_updated_notification_title_system">Xposed modul uppdaterad, systemomstart krävs</string>

--- a/daemon/src/main/res/values-th/strings.xml
+++ b/daemon/src/main/res/values-th/strings.xml
@@ -2,7 +2,8 @@
 <resources>
     <!-- Notification -->
     <string name="module_is_not_activated_yet">โมดูล Xposed ยังไม่ได้เปิดใช้งาน</string>
-    <string name="module_is_not_activated_yet_detailed">ติดตั้ง %s แล้ว แต่ยังไม่เปิดใช้งาน</string>
+    <string name="module_is_not_activated_yet_main_user_detailed">ติดตั้ง %s แล้ว แต่ยังไม่เปิดใช้งาน</string>
+    <string name="module_is_not_activated_yet_multi_user_detailed">ติดตั้ง %s แล้ว แต่ยังไม่เปิดใช้งาน</string>
     <string name="xposed_module_updated_notification_title">โมดูล Xposed อัปเดตแล้ว</string>
     <string name="xposed_module_updated_notification_content">%s ได้รับการอัปเดตแล้ว โปรดบังคับหยุดและรีสตาร์ทแอปที่อยู่ในขอบเขต</string>
     <string name="xposed_module_updated_notification_title_system">อัปเดตโมดูล Xposed จำเป็นต้องรีบูตระบบ</string>

--- a/daemon/src/main/res/values-tr/strings.xml
+++ b/daemon/src/main/res/values-tr/strings.xml
@@ -2,7 +2,8 @@
 <resources>
     <!-- Notification -->
     <string name="module_is_not_activated_yet">Xposed modülü henüz etkinleştirilmedi</string>
-    <string name="module_is_not_activated_yet_detailed">%s kuruldu, ancak henüz etkinleştirilmedi</string>
+    <string name="module_is_not_activated_yet_main_user_detailed">%s kuruldu, ancak henüz etkinleştirilmedi</string>
+    <string name="module_is_not_activated_yet_multi_user_detailed">%s kuruldu, ancak henüz etkinleştirilmedi</string>
     <string name="xposed_module_updated_notification_title">Xposed modül güncellemesi</string>
     <string name="xposed_module_updated_notification_content">%s güncellendi, lütfen kapsamındaki uygulamaları durdurmaya ve yeniden başlatmaya zorlayın</string>
     <string name="xposed_module_updated_notification_title_system">Xposed modülü güncellendi, sistemin yeniden başlatılması gerekiyor</string>

--- a/daemon/src/main/res/values-uk/strings.xml
+++ b/daemon/src/main/res/values-uk/strings.xml
@@ -2,7 +2,8 @@
 <resources>
     <!-- Notification -->
     <string name="module_is_not_activated_yet">Модуль Xposed ще не активований</string>
-    <string name="module_is_not_activated_yet_detailed">%s було встановлено, але ще не активовано</string>
+    <string name="module_is_not_activated_yet_main_user_detailed">%s було встановлено, але ще не активовано</string>
+    <string name="module_is_not_activated_yet_multi_user_detailed">%s було встановлено, але ще не активовано</string>
     <string name="xposed_module_updated_notification_title">Модуль Xposed оновлено</string>
     <string name="xposed_module_updated_notification_content">%s було оновлено, будь ласка, примусово перезапустіть програми з області модуля</string>
     <string name="xposed_module_updated_notification_title_system">Модуль Xposed оновлено, необхідне перезавантаження системи</string>

--- a/daemon/src/main/res/values-ur/strings.xml
+++ b/daemon/src/main/res/values-ur/strings.xml
@@ -2,7 +2,8 @@
 <resources>
     <!-- Notification -->
     <string name="module_is_not_activated_yet">Xposed ماڈیول ابھی تک چالو نہیں ہوا ہے۔</string>
-    <string name="module_is_not_activated_yet_detailed">%s انسٹال ہو چکا ہے، لیکن ابھی تک چالو نہیں ہوا ہے۔</string>
+    <string name="module_is_not_activated_yet_main_user_detailed">%s انسٹال ہو چکا ہے، لیکن ابھی تک چالو نہیں ہوا ہے۔</string>
+    <string name="module_is_not_activated_yet_multi_user_detailed">%s انسٹال ہو چکا ہے، لیکن ابھی تک چالو نہیں ہوا ہے۔</string>
     <string name="xposed_module_updated_notification_title">Xposed ماڈیول کو اپ ڈیٹ کر دیا گیا۔</string>
     <string name="xposed_module_updated_notification_content">%s کو اپ ڈیٹ کر دیا گیا ہے، براہ کرم اس کے دائرہ کار میں ایپس کو زبردستی روکنے اور دوبارہ شروع کریں۔</string>
     <string name="xposed_module_updated_notification_title_system">Xposed ماڈیول کو اپ ڈیٹ کر دیا گیا، سسٹم ریبوٹ درکار ہے۔</string>

--- a/daemon/src/main/res/values-vi/strings.xml
+++ b/daemon/src/main/res/values-vi/strings.xml
@@ -2,7 +2,8 @@
 <resources>
     <!-- Notification -->
     <string name="module_is_not_activated_yet">Mô-đun Xposed chưa được kích hoạt</string>
-    <string name="module_is_not_activated_yet_detailed">%s đã được cài đặt, nhưng chưa được kích hoạt</string>
+    <string name="module_is_not_activated_yet_main_user_detailed">%s đã được cài đặt, nhưng chưa được kích hoạt</string>
+    <string name="module_is_not_activated_yet_multi_user_detailed">%s đã được cài đặt, nhưng chưa được kích hoạt</string>
     <string name="xposed_module_updated_notification_title">Mô-đun Xposed đã được cập nhật</string>
     <string name="xposed_module_updated_notification_content">%s đã được cập nhật, xin hãy buộc dừng và khởi động lại ứng dụng liên quan</string>
     <string name="xposed_module_updated_notification_title_system">Mô-đun Xposed đã được cập nhật, yêu cầu khởi động lại hệ thống</string>

--- a/daemon/src/main/res/values-zh-rCN/strings.xml
+++ b/daemon/src/main/res/values-zh-rCN/strings.xml
@@ -2,7 +2,8 @@
 <resources>
     <!-- Notification -->
     <string name="module_is_not_activated_yet">Xposed 模块尚未激活</string>
-    <string name="module_is_not_activated_yet_detailed">%1$s 已安装到用户 %2$s，但尚未激活</string>
+    <string name="module_is_not_activated_yet_main_user_detailed">%1$s 已安装，但尚未激活</string>
+    <string name="module_is_not_activated_yet_multi_user_detailed">%1$s 已安装到用户 %2$s，但尚未激活</string>
     <string name="xposed_module_updated_notification_title">Xposed 模块已更新</string>
     <string name="xposed_module_updated_notification_content">%s 已更新，请强行停止并重新打开其作用域内的应用</string>
     <string name="xposed_module_updated_notification_title_system">Xposed 模块已更新，需要重新启动</string>

--- a/daemon/src/main/res/values-zh-rHK/strings.xml
+++ b/daemon/src/main/res/values-zh-rHK/strings.xml
@@ -2,7 +2,8 @@
 <resources>
     <!-- Notification -->
     <string name="module_is_not_activated_yet">Xposed 模組尚未啟動</string>
-    <string name="module_is_not_activated_yet_detailed">%s 已安裝, 但尚未啟動</string>
+    <string name="module_is_not_activated_yet_main_user_detailed">%1$s 已安裝，但尚未啟動</string>
+    <string name="module_is_not_activated_yet_multi_user_detailed">%1$s 已安裝到用戶 %2$s，但尚未啟動</string>
     <string name="xposed_module_updated_notification_title">Xposed 模組已更新</string>
     <string name="xposed_module_updated_notification_content">%s 已更新</string>
     <string name="xposed_module_updated_notification_title_system">Xposed模組已更新，需要重啟系統。</string>

--- a/daemon/src/main/res/values-zh-rTW/strings.xml
+++ b/daemon/src/main/res/values-zh-rTW/strings.xml
@@ -2,7 +2,8 @@
 <resources>
     <!-- Notification -->
     <string name="module_is_not_activated_yet">Xposed 模組尚未啟用</string>
-    <string name="module_is_not_activated_yet_detailed">%s 已安裝，但尚未啟用</string>
+    <string name="module_is_not_activated_yet_main_user_detailed">%1$s 已安裝，但尚未啟用</string>
+    <string name="module_is_not_activated_yet_multi_user_detailed">%1$s 已安裝到用戶 %2$s, 但尚未啟用</string>
     <string name="xposed_module_updated_notification_title">Xposed 模組已更新</string>
     <string name="xposed_module_updated_notification_content">%s 已更新，請強制停止並重新打開其作用域內的程式</string>
     <string name="xposed_module_updated_notification_title_system">Xposed 模組已更新，需要重新啟動。</string>

--- a/daemon/src/main/res/values/strings.xml
+++ b/daemon/src/main/res/values/strings.xml
@@ -1,7 +1,8 @@
 <resources>
     <!-- Notification -->
     <string name="module_is_not_activated_yet">Xposed module is not activated yet</string>
-    <string name="module_is_not_activated_yet_detailed">%1$s has been installed to user %2$s, but is not activated yet</string>
+    <string name="module_is_not_activated_yet_main_user_detailed">%1$s has been installed, but is not activated yet</string>
+    <string name="module_is_not_activated_yet_multi_user_detailed">%1$s has been installed to user %2$s, but is not activated yet</string>
     <string name="xposed_module_updated_notification_title">Xposed module updated</string>
     <string name="xposed_module_updated_notification_content">%s has been updated, please force stop and restart apps in its scope</string>
     <string name="xposed_module_updated_notification_title_system">Xposed module updated, system reboot required</string>

--- a/hiddenapi/stubs/src/main/java/android/app/INotificationManager.java
+++ b/hiddenapi/stubs/src/main/java/android/app/INotificationManager.java
@@ -9,6 +9,7 @@ import android.os.RemoteException;
 public interface INotificationManager extends IInterface {
     void enqueueNotificationWithTag(String pkg, String opPkg, String tag, int id,
                                     Notification notification, int userId) throws RemoteException;
+    void cancelNotificationWithTag(String pkg, String opPkg, String tag, int id, int userId) throws RemoteException;
     void createNotificationChannels(String pkg, ParceledListSlice<NotificationChannel> channelsList) throws RemoteException;
 
     abstract class Stub extends Binder implements INotificationManager {


### PR DESCRIPTION
After the main user installs the Xposed Module, the notification is considered not to need to display the current owner's username, and will only be displayed during multi-user installations.

在主用户安装 Xposed Module 后，通知应当不需要显示当前机主的用户名，在多用户安装时才会显示。