### PR TITLE
Fix crash when dlopen NULL

### DIFF
--- a/core/src/main/jni/src/native_api.cpp
+++ b/core/src/main/jni/src/native_api.cpp
@@ -101,7 +101,7 @@ namespace lspd {
                 } else {
                     ns = "NULL";
                 }
-                LOGD("native_api: do_dlopen({})", name);
+                LOGD("native_api: do_dlopen({})", ns);
                 if (handle == nullptr) {
                     return nullptr;
                 }


### PR DESCRIPTION
Fix SIGABRT when `LOGD("native_api: do_dlopen({})", name);` when `name == NULL` in debug build