### PR TITLE
LSPManagerService: Change SELinux label of entire cache directory (#1933)

### DIFF
--- a/daemon/src/main/java/org/lsposed/lspd/service/LSPManagerService.java
+++ b/daemon/src/main/java/org/lsposed/lspd/service/LSPManagerService.java
@@ -430,12 +430,10 @@ public class LSPManagerService extends ILSPManagerService.Stub {
             if (pkgInfo != null) {
                 cacheDir = new File(HiddenApiBridge.ApplicationInfo_credentialProtectedDataDir(pkgInfo.applicationInfo) + "/cache");
             }
-            var webviewDir = new File(cacheDir, "WebView");
-            webviewDir.mkdirs();
-            var httpCacheDir = new File(cacheDir, "http_cache");
-            httpCacheDir.mkdirs();
-            ensureWebViewPermission(webviewDir);
-            ensureWebViewPermission(httpCacheDir);
+
+            // The cache directory does not exist after `pm clear`
+            cacheDir.mkdirs();
+            ensureWebViewPermission(cacheDir);
         } catch (Throwable e) {
             Log.w(TAG, "cannot ensure webview dir", e);
         }


### PR DESCRIPTION
With webview on Android 13 Beta (at least on Google Pixel devices), webview expects to be able to read from a randomly generated temp directory:

    /data/user/0/com.android.shell/cache/.com.google.Chrome.XXXXXX (deleted)

Before this change, the root of the cache directory is labeled with `shell_data_file` and `Chrome_ChildIOT` is not permitted read access to the temp directory:

    05-12 10:59:48.728 13692 13692 W Chrome_ChildIOT: type=1400 audit(0.0:258): avc: denied { read } for path=2F646174612F757365722F302F636F6D2E616E64726F69642E7368656C6C2F63616368652F2E636F6D2E676F6F676C652E4368726F6D652E5965394D6433202864656C6574656429 dev="dm-47" ino=230834 scontext=u:r:isolated_app:s0:c512,c768 tcontext=u:object_r:shell_data_file:s0 tclass=file permissive=0