### PR TITLE
Fix resource hook on MediaTek

### DIFF
--- a/core/src/main/java/de/robv/android/xposed/XposedBridge.java
+++ b/core/src/main/java/de/robv/android/xposed/XposedBridge.java
@@ -143,9 +143,10 @@ public final class XposedBridge {
             // Used by com.mediatek.res.AsyncDrawableCache.putCacheList
             if (contextField != null) {
                 var mediatekCompat = new ContextWrapper(null) {
+                    private final ApplicationInfo info = new ApplicationInfo();
+
                     @Override
                     public ApplicationInfo getApplicationInfo() {
-                        var info = new ApplicationInfo();
                         info.processName = "system";
                         return info;
                     }

--- a/core/src/main/java/de/robv/android/xposed/XposedBridge.java
+++ b/core/src/main/java/de/robv/android/xposed/XposedBridge.java
@@ -20,10 +20,11 @@
 
 package de.robv.android.xposed;
 
-import static de.robv.android.xposed.XposedHelpers.setObjectField;
-
 import android.app.ActivityThread;
+import android.content.ContextWrapper;
+import android.content.pm.ApplicationInfo;
 import android.content.res.Resources;
+import android.content.res.ResourcesImpl;
 import android.content.res.TypedArray;
 import android.util.Log;
 
@@ -50,7 +51,6 @@ import de.robv.android.xposed.callbacks.XC_LoadPackage;
  * This class contains most of Xposed's central logic, such as initialization and callbacks used by
  * the native side. It also includes methods to add new hooks.
  */
-@SuppressWarnings("JniMissingFunction")
 public final class XposedBridge {
     /**
      * The system class loader which can be used to locate Android framework classes.
@@ -133,10 +133,28 @@ public final class XposedBridge {
             ResourcesHook.makeInheritable(resClass);
             ResourcesHook.makeInheritable(taClass);
             ClassLoader myCL = XposedBridge.class.getClassLoader();
+            assert myCL != null;
             dummyClassLoader = ResourcesHook.buildDummyClassLoader(myCL.getParent(), resClass.getName(), taClass.getName());
             dummyClassLoader.loadClass("xposed.dummy.XResourcesSuperClass");
             dummyClassLoader.loadClass("xposed.dummy.XTypedArraySuperClass");
-            setObjectField(myCL, "parent", dummyClassLoader);
+            XposedHelpers.setObjectField(myCL, "parent", dummyClassLoader);
+
+            var contextField = XposedHelpers.findFieldIfExists(ResourcesImpl.class, "mAppContext");
+            // Used by com.mediatek.res.AsyncDrawableCache.putCacheList
+            if (contextField != null) {
+                var mediatekCompat = new ContextWrapper(null) {
+                    @Override
+                    public ApplicationInfo getApplicationInfo() {
+                        var info = new ApplicationInfo();
+                        info.processName = "system";
+                        return info;
+                    }
+                };
+
+                // This field will be updated to correct value
+                // after ContextImpl.createAppContext
+                contextField.set(null, mediatekCompat);
+            }
         } catch (Throwable throwable) {
             XposedBridge.log(throwable);
             XposedInit.disableResources = true;
@@ -405,7 +423,7 @@ public final class XposedBridge {
             } else {
                 returnType = null;
             }
-            params = new Object[] {
+            params = new Object[]{
                     method,
                     returnType,
                     isStatic,


### PR DESCRIPTION
```
Caused by: java.lang.NullPointerException: Attempt to invoke virtual method 'android.content.pm.ApplicationInfo android.content.Context.getApplicationInfo()' on a null object reference
	at com.mediatek.res.AsyncDrawableCache.putCacheList(AsyncDrawableCache.java:165)
	at com.mediatek.res.ResOptExtImpl.putCacheList(ResOptExtImpl.java:69)
	at android.content.res.ResourcesImpl.cacheDrawable(ResourcesImpl.java:800)
	at android.content.res.ResourcesImpl.loadDrawable(ResourcesImpl.java:737)
	at android.content.res.MiuiResourcesImpl.loadDrawable(MiuiResourcesImpl.java:307)
	at android.content.res.Resources.loadDrawable(Resources.java:1017)
	at android.content.res.Resources.getDrawableForDensity(Resources.java:1005)
	at android.content.res.Resources.getDrawable(Resources.java:944)
	at android.content.res.Resources.getDrawable(Resources.java:919)
	at XposedModuleInit.handleInitPackageResources(XposedModuleInit.java:168)
	at de.robv.android.xposed.IXposedHookInitPackageResources$Wrapper.handleInitPackageResources(Unknown Source:2)
	at de.robv.android.xposed.callbacks.XC_InitPackageResources.call(Unknown Source:6)
	at de.robv.android.xposed.callbacks.XCallback.callAll(Unknown Source:26)
	at de.robv.android.xposed.XposedInit.cloneToXResources(Unknown Source:2)
	at de.robv.android.xposed.XposedInit.b(Unknown Source:0)
	at de.robv.android.xposed.XposedInit$2.afterHookedMethod(Unknown Source:34)
	at de.robv.android.xposed.XposedBridge$AdditionalHookInfo.callback(Unknown Source:151)
	at LSPHooker_.createResources(Unknown Source:17)
	at android.app.ResourcesManager.getResources(ResourcesManager.java:1148)
	at android.app.LoadedApk.getResources(LoadedApk.java:1321)
	at android.app.ContextImpl.createAppContext(ContextImpl.java:3025)
```

https://github.com/realme-mt6785-devs/mtk_fwks/blob/9d89ddd4b5c7b9f24f9244a4d7469c746c9c3717/mediatek-framework/sources/com/mediatek/res/AsyncDrawableCache.java#L104