### PR TITLE
Typo in `AfterHooker` class name

### DIFF
--- a/core/src/main/java/de/robv/android/xposed/XposedBridge.java
+++ b/core/src/main/java/de/robv/android/xposed/XposedBridge.java
@@ -492,7 +492,7 @@ public final class XposedBridge {
                 try {
                     if (HookBridge.instanceOf(cb, XC_MethodHook.class)) {
                         ((XC_MethodHook) cb).afterHookedMethod(param);
-                    } else if (HookBridge.instanceOf(cb, XposedInterface.AfterHookCallback.class)) {
+                    } else if (HookBridge.instanceOf(cb, XposedInterface.AfterHooker.class)) {
                         ((XposedInterface.AfterHooker<T>) cb).after(param);
                     }
                 } catch (Throwable t) {


### PR DESCRIPTION
a typo in the class name that caused afterHook to not work on the new api