### PR TITLE
Skip secondary classloaders that do not include code

### DIFF
--- a/core/src/main/java/org/lsposed/lspd/hooker/LoadedApkGetCLHooker.java
+++ b/core/src/main/java/org/lsposed/lspd/hooker/LoadedApkGetCLHooker.java
@@ -102,6 +102,11 @@ public class LoadedApkGetCLHooker extends XC_MethodHook {
                 return;
             }
 
+            if (!isFirstPackage && !XposedHelpers.getBooleanField(loadedApk, "mIncludeCode")) {
+                Hookers.logD("LoadedApk#<init> mIncludeCode == false: " + mAppDir);
+                return;
+            }
+
             if (!isFirstPackage && !XposedInit.getLoadedModules().getOrDefault(packageName, Optional.of("")).isPresent()) {
                 return;
             }


### PR DESCRIPTION
https://github.com/rovo89/XposedBridge/commit/2ca8d5eb7d0bcf251490f3192286877d4a4dfea8
Restore original xposed behavior