### PR TITLE
Fix the 'lspd' process name

### DIFF
--- a/daemon/src/main/java/org/lsposed/lspd/service/ServiceManager.java
+++ b/daemon/src/main/java/org/lsposed/lspd/service/ServiceManager.java
@@ -133,14 +133,14 @@ public class ServiceManager {
 
         systemServerService.putBinderForSystemServer();
 
-        DdmHandleAppName.setAppName("lspd", 0);
-
         // get config before package service is started
         // otherwise getInstance will trigger module/scope cache
         var configManager = ConfigManager.getInstance();
         // --- DO NOT call ConfigManager.getInstance later!!! ---
 
         ActivityThread.systemMain();
+
+        DdmHandleAppName.setAppName("lspd", 0);
 
         waitSystemService("package");
         waitSystemService("activity");


### PR DESCRIPTION
ActivityThread#systemMain -> ActivityThread#attach will also change the process name to 'system_process', so that there are two 'system_process' processes in the system.

https://android.googlesource.com/platform/frameworks/base/+/0e40462e11d27eb859b829b112cecb8c6f0d7afb/core/java/android/app/ActivityThread.java#5119

![截屏2023-10-07 16 16 30](https://github.com/LSPosed/LSPosed/assets/8243689/ee137210-ffa3-497a-aca1-5c215dd9eaed)
