### PR TITLE
Group all maven dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,11 +5,14 @@ updates:
     schedule:
       interval: daily
       time: "21:00"
-    open-pull-requests-limit: 10
     target-branch: master
     registries:
       - maven-google
       - gradle-plugin
+    groups:
+      maven-dependencies:
+        patterns:
+          - "*"
 
 registries:
   maven-google:


### PR DESCRIPTION
so that dependabot will only open one PR for multiple dependencies update.