### PR TITLE
fix: detect `xposed_init` for `isLegacyModule`

### DIFF
--- a/app/src/main/java/org/lsposed/manager/util/ModuleUtil.java
+++ b/app/src/main/java/org/lsposed/manager/util/ModuleUtil.java
@@ -118,8 +118,25 @@ public final class ModuleUtil {
         return zip;
     }
 
+    // same as org.lsposed.lspd.service.ModuleUtil#isLegacyModule
     public static boolean isLegacyModule(ApplicationInfo info) {
-        return info.metaData != null && info.metaData.containsKey("xposedminversion");
+        if (info.metaData == null || !info.metaData.containsKey("xposedminversion")) {
+            return false;
+        }
+        String[] apks;
+        if (info.splitSourceDirs != null) {
+            apks = Arrays.copyOf(info.splitSourceDirs, info.splitSourceDirs.length + 1);
+            apks[info.splitSourceDirs.length] = info.sourceDir;
+        } else apks = new String[]{info.sourceDir};
+        for (var apk : apks) {
+            try (var zip = new ZipFile(apk)) {
+                if (zip.getEntry("assets/xposed_init") != null) {
+                    return true;
+                }
+            } catch (IOException ignored) {
+            }
+        }
+        return false;
     }
 
     synchronized public void reloadInstalledModules() {


### PR DESCRIPTION
Without this, any legacy module without `assets/xposed_init` would show in module list, but cannot be enabled (when you click `enable`, nothing will happen and no any message/log).
This commit makes such module not shown at all, same as `isModernModules`.

Sample: [app-release.zip](https://github.com/LSPosed/LSPosed/files/13736454/app-release.zip)

For repeated `isLegacyModule`: someone in TG tells me that `lspd` and `manager` should be mostly isolated, so I wrote such code. If this is improper, please feel free to fix it.

More detail about the issue: when module installed, [dispatchPackageChanged](https://github.com/LSPosed/LSPosed/blob/f892443923ecba43a0f6dad3ee98524adf16edcb/daemon/src/main/java/org/lsposed/lspd/service/LSPosedService.java#L136) will detect if it is a legacy module by checking presence of `xposedminversion`; when click `Enable`, [getModuleApkPath will return null](https://github.com/LSPosed/LSPosed/blob/f892443923ecba43a0f6dad3ee98524adf16edcb/daemon/src/main/java/org/lsposed/lspd/service/ConfigManager.java#L970) and thus prevent the module from enabling.